### PR TITLE
fix: add nushell as available completion in help command

### DIFF
--- a/src/linecast/__main__.py
+++ b/src/linecast/__main__.py
@@ -16,7 +16,7 @@ Commands:
   linecast maps        Street and terrain maps: vector streets or hillshaded relief
   linecast location    Show or set a fixed location (overrides IP geolocation)
   linecast units       Show or set preferred units (metric or imperial)
-  linecast completion  Print shell completion script (bash, zsh, fish)
+  linecast completion  Print shell completion script (bash, zsh, fish, nushell)
 
 Each command is also installed as a standalone binary (weather, sunshine,
 moon, tides, radar, maps). Run any command with --help for options.


### PR DESCRIPTION
# Summary

Follow up for https://github.com/ashuttl/linecast/pull/3.

A very small detail that was missed on that PR.

```bash
linecast 1.13.0 — weather, sunlight, tides, radar, the Moon, and maps for the terminal

Commands:
  linecast weather     Weather dashboard with braille temperature curve and alerts
  linecast sunshine    Solar arc inspired by the Apple Watch Solar face
  linecast moon        Moon phase, illumination, and rise/set times
  linecast tides       Tide chart with braille rendering (NOAA, CHS, QLD + global model)
  linecast radar       Weather radar over a braille basemap (US + global)
  linecast maps        Street and terrain maps: vector streets or hillshaded relief
  linecast location    Show or set a fixed location (overrides IP geolocation)
  linecast units       Show or set preferred units (metric or imperial)
  linecast completion  Print shell completion script (bash, zsh, fish)

Each command is also installed as a standalone binary (weather, sunshine,
moon, tides, radar, maps). Run any command with --help for options.
```

After 

```bash
linecast 1.13.0 — weather, sunlight, tides, radar, the Moon, and maps for the terminal

Commands:
  linecast weather     Weather dashboard with braille temperature curve and alerts
  linecast sunshine    Solar arc inspired by the Apple Watch Solar face
  linecast moon        Moon phase, illumination, and rise/set times
  linecast tides       Tide chart with braille rendering (NOAA, CHS, QLD + global model)
  linecast radar       Weather radar over a braille basemap (US + global)
  linecast maps        Street and terrain maps: vector streets or hillshaded relief
  linecast location    Show or set a fixed location (overrides IP geolocation)
  linecast units       Show or set preferred units (metric or imperial)
  linecast completion  Print shell completion script (bash, zsh, fish, nushell)

Each command is also installed as a standalone binary (weather, sunshine,
moon, tides, radar, maps). Run any command with --help for options.
```