### PR TITLE
Weather alerts & tide information from Hong Kong Observatory (HKO)

### DIFF
--- a/src/linecast/_tides_hko.py
+++ b/src/linecast/_tides_hko.py
@@ -1,17 +1,32 @@
 """Hong Kong Observatory (HKO) tide data source.
 
-Uses the HKO Open Data API for tidal stations around Hong Kong.
-All HKO data is in HKT (UTC+8) and metres; this module converts to feet
+Uses the HKO Open Data API (data.weather.gov.hk) for tidal predictions:
+  HHOT — Hourly heights of astronomical tides  (full series, per year)
+  HLT  — Times and heights of high/low tides   (extrema, per year)
+
+Both endpoints require a station code and a year:
+  https://data.weather.gov.hk/weatherAPI/opendata/opendata.php
+    ?dataType=HHOT&station=CCH&year=2026&rformat=json
+
+All HKO data is in HKT (UTC+8) and metres; heights are converted to feet
 for compatibility with the NOAA-based rendering pipeline.
 
-Station list is hard-coded (small, stable, no discovery endpoint):
-  https://tide1.hydro.gov.hk/hotide/OpenData/station_data.php?station=<code>
+Station table: 12 active stations from HHOT dataset.
+Excluded stations (decommissioned, data is computer-simulated per HKO):
+  CMW — Chi Ma Wan, closed 1997
+  LOP — Lok On Pai, closed 1999
 """
 
 from datetime import datetime, timezone, timedelta
 
 from linecast import USER_AGENT
-from linecast._cache import CACHE_ROOT, location_cache_key, read_cache, read_stale, write_cache
+from linecast._cache import (
+    CACHE_ROOT,
+    location_cache_key,
+    read_cache,
+    read_stale,
+    write_cache,
+)
 from linecast._geo import haversine_nm
 from linecast._http import fetch_json
 
@@ -21,15 +36,40 @@ NEAREST_STATION_CACHE_MAX_AGE = 3600
 # Hong Kong does not observe DST; HKT is always UTC+8.
 HKT = timezone(timedelta(hours=8))
 
-# Static station table derived from Tidedata_link_geodatastore_converted.csv
+_HKO_PRED_BASE = "https://data.weather.gov.hk/weatherAPI/opendata/opendata.php"
+
+# ---------------------------------------------------------------------------
+# Station table — coordinates and names from HHOT_HHOT_converted_2.csv
+# (authoritative HKO geodatastore source, EPSG:4326).
+# Decommissioned stations excluded (CMW closed 1997, LOP closed 1999).
+# ---------------------------------------------------------------------------
 _STATIONS = [
-    {"id": "ct8", "name": "Kwai Chung",  "lat": 22.323726, "lng": 114.122665},
-    {"id": "mwc", "name": "Ma Wan",      "lat": 22.363950, "lng": 114.071347},
-    {"id": "chc", "name": "Cheung Chau", "lat": 22.214012, "lng": 114.023014},
-    {"id": "klw", "name": "Ko Lau Wan",  "lat": 22.458492, "lng": 114.360616},
-    {"id": "skt", "name": "Sha Kiu Tau", "lat": 22.348293, "lng": 114.352831},
+    {"id": "CCH", "name": "Cheung Chau", "lat": 22.214167, "lng": 114.023056},
+    {"id": "CLK", "name": "Chek Lap Kok (E)", "lat": 22.320556, "lng": 113.945278},
+    {"id": "KCT", "name": "Kwai Chung", "lat": 22.323611, "lng": 114.122778},
+    {"id": "KLW", "name": "Ko Lau Wan", "lat": 22.458611, "lng": 114.360833},
+    {"id": "MWC", "name": "Ma Wan", "lat": 22.363889, "lng": 114.071389},
+    {"id": "PT1", "name": "Po Toi", "lat": 22.163300, "lng": 114.253100},
+    {"id": "QUB", "name": "Quarry Bay", "lat": 22.291111, "lng": 114.213333},
+    {"id": "SPW", "name": "Shek Pik", "lat": 22.220278, "lng": 113.894444},
+    {"id": "TAO", "name": "Tai O", "lat": 22.255000, "lng": 113.865556},
+    {"id": "TBT", "name": "Tsim Bei Tsui", "lat": 22.487222, "lng": 114.014167},
+    {"id": "TMW", "name": "Tai Miu Wan", "lat": 22.269722, "lng": 114.288611},
+    {"id": "TPK", "name": "Tai Po Kau", "lat": 22.442500, "lng": 114.183889},
+    {"id": "WAG", "name": "Waglan Island", "lat": 22.183056, "lng": 114.302778},
 ]
-_HKO_BASE = "https://tide1.hydro.gov.hk/hotide/OpenData/station_data.php"
+
+# Backwards-compatibility: map old hotide real-time codes → prediction codes.
+# Used when a user specifies --station with a hotide code (ct8, chc, etc.).
+_HOTIDE_TO_HKO = {
+    "chc": "CCH",
+    "ct8": "KCT",
+    "klw": "KLW",
+    "mwc": "MWC",
+    # skt has no prediction data and is intentionally absent
+}
+
+_STATION_BY_ID = {s["id"]: s for s in _STATIONS}
 
 
 # ---------------------------------------------------------------------------
@@ -71,30 +111,76 @@ def find_nearest_station_hko(lat, lng):
 # Station metadata
 # ---------------------------------------------------------------------------
 def fetch_station_metadata_hko(station_id):
-    """Return HKO station metadata normalised to the shared shape."""
-    for s in _STATIONS:
-        if s["id"] == station_id:
-            return {
-                "id": station_id,
-                "name": s["name"],
-                "state": "HK",
-                "lat": s["lat"],
-                "lng": s["lng"],
-                "timezone_abbr": "HKT",
-                "timezonecorr": 8,
-                "timeZoneCode": "Asia/Hong_Kong",
-                "observedst": False,
-                "source": "hko",
-            }
-    return None
+    """Return HKO station metadata normalised to the shared shape.
+
+    Accepts both prediction codes (CCH) and legacy hotide codes (chc).
+    """
+    # Remap legacy hotide codes transparently
+    hko_id = _HOTIDE_TO_HKO.get(station_id, station_id).upper()
+    s = _STATION_BY_ID.get(hko_id)
+    if s is None:
+        return None
+    return {
+        "id": hko_id,
+        "name": s["name"],
+        "state": "HK",
+        "lat": s["lat"],
+        "lng": s["lng"],
+        "timezone_abbr": "HKT",
+        "timezonecorr": 8,
+        "timeZoneCode": "Asia/Hong_Kong",
+        "observedst": False,
+        "source": "hko",
+    }
 
 
 # ---------------------------------------------------------------------------
-# Datetime helpers
+# Internal: prediction API helpers
 # ---------------------------------------------------------------------------
-def _parse_hko_dt(s):
-    """Parse HKO datetime string 'YYYY-MM-DD HH:MM' to HKT-aware datetime."""
-    return datetime.strptime(s, "%Y-%m-%d %H:%M").replace(tzinfo=HKT)
+def _resolve_id(station_id):
+    """Normalise station_id: hotide codes → HKO prediction codes."""
+    return _HOTIDE_TO_HKO.get(station_id, station_id).upper()
+
+
+def _pred_url(data_type, hko_code, year):
+    return (
+        f"{_HKO_PRED_BASE}"
+        f"?dataType={data_type}&station={hko_code}&year={year}&rformat=json"
+    )
+
+
+def _fetch_year_raw(data_type, station_id, year):
+    """Fetch one year of HHOT or HLT data.
+
+    Past years cached 30 days (predictions never change); current year 24 h.
+    Returns the raw 'data' list from the API, or [] on failure.
+    """
+    hko_code = _resolve_id(station_id)
+    if hko_code not in _STATION_BY_ID:
+        return []
+
+    cache_file = CACHE_DIR / f"hko_{data_type.lower()}_{hko_code}_{year}.json"
+    now_year = datetime.now(HKT).year
+    max_age = 30 * 86400 if year < now_year else 86400
+
+    cached = read_cache(cache_file, max_age)
+    if cached is not None:
+        return cached
+
+    url = _pred_url(data_type, hko_code, year)
+    try:
+        data = fetch_json(url, headers={"User-Agent": USER_AGENT}, timeout=20)
+    except Exception:
+        stale = read_stale(cache_file)
+        return stale if stale is not None else []
+
+    if not data or not isinstance(data, dict):
+        return []
+
+    rows = data.get("data", [])
+    if rows:
+        write_cache(cache_file, rows)
+    return rows
 
 
 def _parse_cached_dt(iso_str):
@@ -105,100 +191,80 @@ def _parse_cached_dt(iso_str):
 
 
 # ---------------------------------------------------------------------------
-# Prediction fetching
+# HHOT — hourly heights series
 # ---------------------------------------------------------------------------
-def _fetch_pred_day(station_id, date):
-    """Fetch one day of HKO predictions.  Returns [(datetime_hkt, height_ft)]."""
-    date_str = date.strftime("%Y%m%d")
-    cache_file = CACHE_DIR / f"hko_pred_{station_id}_{date_str}.json"
+def _hhot_rows_to_points(rows, year):
+    """Parse HHOT raw rows into (datetime_hkt, height_ft) tuples.
 
-    cached = read_cache(cache_file, 86400)
-    if cached is not None:
-        return [(_parse_cached_dt(r["dt"]), r["v"]) for r in cached]
-
-    url = f"{_HKO_BASE}?station={station_id}"
-    try:
-        data = fetch_json(url, headers={"User-Agent": USER_AGENT}, timeout=15)
-    except Exception:
-        stale = read_stale(cache_file)
-        if stale:
-            return [(_parse_cached_dt(r["dt"]), r["v"]) for r in stale]
-        return []
-
-    if not data or not isinstance(data, list):
-        return []
-
-    # The API always returns data for "today" from HKO's perspective; filter
-    # to the requested date so range fetches stay clean.
-    day_start = datetime(date.year, date.month, date.day, tzinfo=HKT)
-    day_end = day_start + timedelta(days=1)
-
-    rows = []
+    Each row: [MM, DD, h_at_01, h_at_02, ..., h_at_24]
+    Hour columns are labelled '01'–'24' (HKT local time, 1-based).
+    """
     points = []
-    for rec in data:
+    for row in rows:
         try:
-            dt = _parse_hko_dt(rec["DateTime"])
-            height_ft = float(rec["height"]) * M_TO_FT
-        except (KeyError, ValueError, TypeError):
+            month = int(row[0])
+            day = int(row[1])
+        except (IndexError, ValueError, TypeError):
             continue
-        if day_start <= dt < day_end:
-            rows.append({"dt": dt.isoformat(), "v": height_ft})
+        for hour_idx in range(24):
+            col = hour_idx + 2  # columns 2..25 → hours 01..24
+            val = row[col] if col < len(row) else ""
+            if val == "" or val is None:
+                continue
+            try:
+                height_ft = float(val) * M_TO_FT
+            except (ValueError, TypeError):
+                continue
+            # hour label is 1-based: col index 2 = 01:00 HKT
+            hour = hour_idx + 1
+            if hour == 24:
+                # 24:00 = midnight of the following day
+                try:
+                    dt = datetime(year, month, day, 0, 0, tzinfo=HKT) + timedelta(
+                        days=1
+                    )
+                except ValueError:
+                    continue
+            else:
+                try:
+                    dt = datetime(year, month, day, hour, 0, tzinfo=HKT)
+                except ValueError:
+                    continue
             points.append((dt, height_ft))
-
-    if rows:
-        write_cache(cache_file, rows)
     return points
 
 
-def fetch_tides_range_hko(station_id, start_date, end_date, station_tz=None):
-    """Fetch HKO interval predictions across a date range.
+def _fetch_hhot_year(station_id, year):
+    """Return list of (datetime_hkt, height_ft) for a full year via HHOT."""
+    hko_code = _resolve_id(station_id)
+    cache_file = CACHE_DIR / f"hko_hhot_pts_{hko_code}_{year}.json"
+    now_year = datetime.now(HKT).year
+    max_age = 30 * 86400 if year < now_year else 86400
 
-    Returns sorted list of (datetime, height_ft) tuples.
-    station_tz is accepted for API compatibility but HKO is always HKT.
+    cached = read_cache(cache_file, max_age)
+    if cached is not None:
+        return [(_parse_cached_dt(r["dt"]), r["v"]) for r in cached]
 
-    Note: the HKO open-data endpoint returns the current day only; for
-    dates in the past or future the cache may be empty and the result will
-    be an empty list for those days.  The live view and static render will
-    both fall through to hilo-based synthesis in that case.
-    """
-    points = []
-    d = start_date
-    while d <= end_date:
-        points.extend(_fetch_pred_day(station_id, d))
-        d += timedelta(days=1)
+    rows = _fetch_year_raw("HHOT", station_id, year)
+    if not rows:
+        return []
 
-    seen = set()
-    unique = []
-    for dt, h in points:
-        key = dt.replace(second=0, microsecond=0)
-        if key not in seen:
-            seen.add(key)
-            unique.append((dt, h))
-    unique.sort(key=lambda p: p[0])
-    return unique
+    points = _hhot_rows_to_points(rows, year)
+    cache_rows = [{"dt": dt.isoformat(), "v": v} for dt, v in points]
+    if cache_rows:
+        write_cache(cache_file, cache_rows)
+    return points
 
 
 # ---------------------------------------------------------------------------
-# High/low detection (same approach as QLD)
+# HLT — high/low extrema
 # ---------------------------------------------------------------------------
-def _find_extrema(points):
-    if len(points) < 3:
-        return list(points)
-    extrema = []
-    for i in range(1, len(points) - 1):
-        _, h_prev = points[i - 1]
-        dt_curr, h_curr = points[i]
-        _, h_next = points[i + 1]
-        if (h_curr > h_prev and h_curr >= h_next) or (h_curr < h_prev and h_curr <= h_next):
-            extrema.append((dt_curr, h_curr))
-    return extrema
-
-
 def _label_hilo(values):
+    """Assign H/L by comparing each point against its neighbours."""
     if not values:
         return []
     if len(values) == 1:
-        return [(*values[0], "H")]
+        return [(values[0][0], values[0][1], "H")]
     labeled = []
     for i, (dt, height) in enumerate(values):
         if i == 0:
@@ -211,29 +277,133 @@ def _label_hilo(values):
     return labeled
 
 
-def fetch_hilo_range_hko(station_id, start_date, end_date, station_tz=None):
-    """Derive high/low extremes from the HKO prediction series."""
-    preds = fetch_tides_range_hko(station_id, start_date, end_date, station_tz)
-    if not preds:
+def _hlt_rows_to_hilo(rows, year):
+    """Parse HLT raw rows into (datetime_hkt, height_ft, 'H'|'L') tuples.
+
+    Each row: [Month, Date, Time1, Height1, Time2, Height2, Time3, Height3, Time4, Height4]
+    Up to 4 events per day; empty string signals fewer events that day.
+    H/L labels are derived by comparison with adjacent events.
+    """
+    raw = []
+    for row in rows:
+        try:
+            month = int(row[0])
+            day = int(row[1])
+        except (IndexError, ValueError, TypeError):
+            continue
+        for slot in range(4):
+            t_col = 2 + slot * 2
+            h_col = 3 + slot * 2
+            t_str = row[t_col] if t_col < len(row) else ""
+            h_str = row[h_col] if h_col < len(row) else ""
+            if not t_str:
+                break
+            try:
+                hhmm = t_str.zfill(4)
+                hour = int(hhmm[:2])
+                minute = int(hhmm[2:])
+                height_ft = float(h_str) * M_TO_FT
+            except (ValueError, TypeError):
+                continue
+            try:
+                dt = datetime(year, month, day, hour, minute, tzinfo=HKT)
+            except ValueError:
+                continue
+            raw.append((dt, height_ft))
+
+    raw.sort(key=lambda p: p[0])
+    return _label_hilo(raw)
+
+
+def _fetch_hlt_year(station_id, year):
+    """Return list of (datetime_hkt, height_ft, 'H'|'L') for a full year via HLT."""
+    hko_code = _resolve_id(station_id)
+    cache_file = CACHE_DIR / f"hko_hlt_pts_{hko_code}_{year}.json"
+    now_year = datetime.now(HKT).year
+    max_age = 30 * 86400 if year < now_year else 86400
+
+    cached = read_cache(cache_file, max_age)
+    if cached is not None:
+        return [(_parse_cached_dt(r["dt"]), r["v"], r["t"]) for r in cached]
+
+    rows = _fetch_year_raw("HLT", station_id, year)
+    if not rows:
         return []
-    extrema = _find_extrema(preds)
-    return _label_hilo(extrema) if extrema else []
+
+    hilo = _hlt_rows_to_hilo(rows, year)
+    cache_rows = [{"dt": dt.isoformat(), "v": v, "t": t} for dt, v, t in hilo]
+    if cache_rows:
+        write_cache(cache_file, cache_rows)
+    return hilo
+
+
+# ---------------------------------------------------------------------------
+# Public range fetchers
+# ---------------------------------------------------------------------------
+def _years_for_range(start_date, end_date):
+    return list(range(start_date.year, end_date.year + 1))
+
+
+def fetch_tides_range_hko(station_id, start_date, end_date, station_tz=None):
+    """Fetch HKO hourly predictions across a date range.
+
+    Returns sorted list of (datetime, height_ft) tuples.
+    station_tz is accepted for API compatibility but HKO is always HKT.
+    """
+    window_start = datetime(
+        start_date.year, start_date.month, start_date.day, tzinfo=HKT
+    )
+    window_end = datetime(
+        end_date.year, end_date.month, end_date.day, tzinfo=HKT
+    ) + timedelta(days=1)
+
+    points = []
+    for year in _years_for_range(start_date, end_date):
+        for dt, h in _fetch_hhot_year(station_id, year):
+            if window_start <= dt < window_end:
+                points.append((dt, h))
+
+    points.sort(key=lambda p: p[0])
+    return points
+
+
+def fetch_hilo_range_hko(station_id, start_date, end_date, station_tz=None):
+    """Fetch HKO high/low extremes across a date range.
+
+    Returns sorted list of (datetime, height_ft, 'H'|'L') tuples.
+    """
+    window_start = datetime(
+        start_date.year, start_date.month, start_date.day, tzinfo=HKT
+    )
+    window_end = datetime(
+        end_date.year, end_date.month, end_date.day, tzinfo=HKT
+    ) + timedelta(days=1)
+
+    hilo = []
+    for year in _years_for_range(start_date, end_date):
+        for dt, h, t in _fetch_hlt_year(station_id, year):
+            if window_start <= dt < window_end:
+                hilo.append((dt, h, t))
+
+    hilo.sort(key=lambda p: p[0])
+    return hilo
 
 
 def fetch_y_range_hko(station_id, center_date, station_tz=None):
-    """Y-axis range from a ±3-day window of HKO data.  Cached 7 days."""
-    start = center_date - timedelta(days=3)
-    end = center_date + timedelta(days=3)
+    """Y-axis range from ±30 days of HLT data.  Cached 7 days."""
+    start = center_date - timedelta(days=30)
+    end = center_date + timedelta(days=30)
+    hko_code = _resolve_id(station_id)
     start_str = start.strftime("%Y%m%d")
     end_str = end.strftime("%Y%m%d")
-    cache_file = CACHE_DIR / f"hko_yrange_{station_id}_{start_str}_{end_str}.json"
+    cache_file = CACHE_DIR / f"hko_yrange_{hko_code}_{start_str}_{end_str}.json"
 
     cached = read_cache(cache_file, 7 * 86400)
     if cached is not None:
         return (cached["min"], cached["max"])
 
     hilo = fetch_hilo_range_hko(station_id, start, end, station_tz)
-    heights = [h for _, h, _ in hilo] if hilo else []
+    heights = [h for _, h, _ in hilo]
     if not heights:
         preds = fetch_tides_range_hko(station_id, start, end, station_tz)
         heights = [h for _, h in preds]

--- a/src/linecast/_tides_hko.py
+++ b/src/linecast/_tides_hko.py
@@ -1,0 +1,245 @@
+"""Hong Kong Observatory (HKO) tide data source.
+
+Uses the HKO Open Data API for tidal stations around Hong Kong.
+All HKO data is in HKT (UTC+8) and metres; this module converts to feet
+for compatibility with the NOAA-based rendering pipeline.
+
+Station list is hard-coded (small, stable, no discovery endpoint):
+  https://tide1.hydro.gov.hk/hotide/OpenData/station_data.php?station=<code>
+"""
+
+from datetime import datetime, timezone, timedelta
+
+from linecast import USER_AGENT
+from linecast._cache import CACHE_ROOT, location_cache_key, read_cache, read_stale, write_cache
+from linecast._geo import haversine_nm
+from linecast._http import fetch_json
+
+CACHE_DIR = CACHE_ROOT / "tides"
+M_TO_FT = 1 / 0.3048
+NEAREST_STATION_CACHE_MAX_AGE = 3600
+# Hong Kong does not observe DST; HKT is always UTC+8.
+HKT = timezone(timedelta(hours=8))
+
+# Static station table derived from Tidedata_link_geodatastore_converted.csv
+_STATIONS = [
+    {"id": "ct8", "name": "Kwai Chung",  "lat": 22.323726, "lng": 114.122665},
+    {"id": "mwc", "name": "Ma Wan",      "lat": 22.363950, "lng": 114.071347},
+    {"id": "chc", "name": "Cheung Chau", "lat": 22.214012, "lng": 114.023014},
+    {"id": "klw", "name": "Ko Lau Wan",  "lat": 22.458492, "lng": 114.360616},
+    {"id": "skt", "name": "Sha Kiu Tau", "lat": 22.348293, "lng": 114.352831},
+]
+_HKO_BASE = "https://tide1.hydro.gov.hk/hotide/OpenData/station_data.php"
+
+
+# ---------------------------------------------------------------------------
+# Station discovery (static list — no network call needed)
+# ---------------------------------------------------------------------------
+def _fetch_all_stations_hko():
+    """Return the static HKO station list (no network needed)."""
+    return _STATIONS
+
+
+def find_nearest_station_hko(lat, lng):
+    """Find closest HKO tide station by haversine distance.
+
+    Returns (station_id, station_name) or (None, None).  Cached 1 hour.
+    Returns None when the nearest station is > 100 nm away.
+    """
+    cache_file = CACHE_DIR / f"hko_station_{location_cache_key(lat, lng)}.json"
+    cached = read_cache(cache_file, NEAREST_STATION_CACHE_MAX_AGE)
+    if cached:
+        return cached["id"], cached["name"]
+
+    best_id, best_name, best_dist = None, None, float("inf")
+    for s in _STATIONS:
+        d = haversine_nm(lat, lng, s["lat"], s["lng"])
+        if d < best_dist:
+            best_dist = d
+            best_id = s["id"]
+            best_name = s["name"]
+
+    if best_dist > 100:
+        return None, None
+
+    result = {"id": best_id, "name": best_name}
+    write_cache(cache_file, result)
+    return best_id, best_name
+
+
+# ---------------------------------------------------------------------------
+# Station metadata
+# ---------------------------------------------------------------------------
+def fetch_station_metadata_hko(station_id):
+    """Return HKO station metadata normalised to the shared shape."""
+    for s in _STATIONS:
+        if s["id"] == station_id:
+            return {
+                "id": station_id,
+                "name": s["name"],
+                "state": "HK",
+                "lat": s["lat"],
+                "lng": s["lng"],
+                "timezone_abbr": "HKT",
+                "timezonecorr": 8,
+                "timeZoneCode": "Asia/Hong_Kong",
+                "observedst": False,
+                "source": "hko",
+            }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Datetime helpers
+# ---------------------------------------------------------------------------
+def _parse_hko_dt(s):
+    """Parse HKO datetime string 'YYYY-MM-DD HH:MM' to HKT-aware datetime."""
+    return datetime.strptime(s, "%Y-%m-%d %H:%M").replace(tzinfo=HKT)
+
+
+def _parse_cached_dt(iso_str):
+    dt = datetime.fromisoformat(iso_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=HKT)
+    return dt
+
+
+# ---------------------------------------------------------------------------
+# Prediction fetching
+# ---------------------------------------------------------------------------
+def _fetch_pred_day(station_id, date):
+    """Fetch one day of HKO predictions.  Returns [(datetime_hkt, height_ft)]."""
+    date_str = date.strftime("%Y%m%d")
+    cache_file = CACHE_DIR / f"hko_pred_{station_id}_{date_str}.json"
+
+    cached = read_cache(cache_file, 86400)
+    if cached is not None:
+        return [(_parse_cached_dt(r["dt"]), r["v"]) for r in cached]
+
+    url = f"{_HKO_BASE}?station={station_id}"
+    try:
+        data = fetch_json(url, headers={"User-Agent": USER_AGENT}, timeout=15)
+    except Exception:
+        stale = read_stale(cache_file)
+        if stale:
+            return [(_parse_cached_dt(r["dt"]), r["v"]) for r in stale]
+        return []
+
+    if not data or not isinstance(data, list):
+        return []
+
+    # The API always returns data for "today" from HKO's perspective; filter
+    # to the requested date so range fetches stay clean.
+    day_start = datetime(date.year, date.month, date.day, tzinfo=HKT)
+    day_end = day_start + timedelta(days=1)
+
+    rows = []
+    points = []
+    for rec in data:
+        try:
+            dt = _parse_hko_dt(rec["DateTime"])
+            height_ft = float(rec["height"]) * M_TO_FT
+        except (KeyError, ValueError, TypeError):
+            continue
+        if day_start <= dt < day_end:
+            rows.append({"dt": dt.isoformat(), "v": height_ft})
+            points.append((dt, height_ft))
+
+    if rows:
+        write_cache(cache_file, rows)
+    return points
+
+
+def fetch_tides_range_hko(station_id, start_date, end_date, station_tz=None):
+    """Fetch HKO interval predictions across a date range.
+
+    Returns sorted list of (datetime, height_ft) tuples.
+    station_tz is accepted for API compatibility but HKO is always HKT.
+
+    Note: the HKO open-data endpoint returns the current day only; for
+    dates in the past or future the cache may be empty and the result will
+    be an empty list for those days.  The live view and static render will
+    both fall through to hilo-based synthesis in that case.
+    """
+    points = []
+    d = start_date
+    while d <= end_date:
+        points.extend(_fetch_pred_day(station_id, d))
+        d += timedelta(days=1)
+
+    seen = set()
+    unique = []
+    for dt, h in points:
+        key = dt.replace(second=0, microsecond=0)
+        if key not in seen:
+            seen.add(key)
+            unique.append((dt, h))
+    unique.sort(key=lambda p: p[0])
+    return unique
+
+
+# ---------------------------------------------------------------------------
+# High/low detection (same approach as QLD)
+# ---------------------------------------------------------------------------
+def _find_extrema(points):
+    if len(points) < 3:
+        return list(points)
+    extrema = []
+    for i in range(1, len(points) - 1):
+        _, h_prev = points[i - 1]
+        dt_curr, h_curr = points[i]
+        _, h_next = points[i + 1]
+        if (h_curr > h_prev and h_curr >= h_next) or (h_curr < h_prev and h_curr <= h_next):
+            extrema.append((dt_curr, h_curr))
+    return extrema
+
+
+def _label_hilo(values):
+    if not values:
+        return []
+    if len(values) == 1:
+        return [(*values[0], "H")]
+    labeled = []
+    for i, (dt, height) in enumerate(values):
+        if i == 0:
+            is_high = height > values[1][1]
+        elif i == len(values) - 1:
+            is_high = height > values[-2][1]
+        else:
+            is_high = height > values[i - 1][1] and height > values[i + 1][1]
+        labeled.append((dt, height, "H" if is_high else "L"))
+    return labeled
+
+
+def fetch_hilo_range_hko(station_id, start_date, end_date, station_tz=None):
+    """Derive high/low extremes from the HKO prediction series."""
+    preds = fetch_tides_range_hko(station_id, start_date, end_date, station_tz)
+    if not preds:
+        return []
+    extrema = _find_extrema(preds)
+    return _label_hilo(extrema) if extrema else []
+
+
+def fetch_y_range_hko(station_id, center_date, station_tz=None):
+    """Y-axis range from a ±3-day window of HKO data.  Cached 7 days."""
+    start = center_date - timedelta(days=3)
+    end = center_date + timedelta(days=3)
+    start_str = start.strftime("%Y%m%d")
+    end_str = end.strftime("%Y%m%d")
+    cache_file = CACHE_DIR / f"hko_yrange_{station_id}_{start_str}_{end_str}.json"
+
+    cached = read_cache(cache_file, 7 * 86400)
+    if cached is not None:
+        return (cached["min"], cached["max"])
+
+    hilo = fetch_hilo_range_hko(station_id, start, end, station_tz)
+    heights = [h for _, h, _ in hilo] if hilo else []
+    if not heights:
+        preds = fetch_tides_range_hko(station_id, start, end, station_tz)
+        heights = [h for _, h in preds]
+    if not heights:
+        return None
+
+    result = {"min": min(heights), "max": max(heights)}
+    write_cache(cache_file, result)
+    return (result["min"], result["max"])

--- a/src/linecast/_weather_sources.py
+++ b/src/linecast/_weather_sources.py
@@ -144,6 +144,13 @@ def fetch_alerts(lat, lng, country_code="", lang="en", address=None):
         return _fetch_alerts_meteireann(lat, lng)
     if country_code == "JP":
         return _fetch_alerts_jma(lat, lng, lang=lang)
+    # Hong Kong has its own observatory — check before the generic CN path.
+    # Nominatim returns country_code "HK" for Hong Kong SAR; some providers
+    # return "CN" with city="Hong Kong", so we check both.
+    addr = address or {}
+    _hk_city = addr.get("city") or addr.get("town") or addr.get("county") or ""
+    if country_code == "HK" or (country_code == "CN" and "Hong Kong" in _hk_city):
+        return _fetch_alerts_hko()
     if country_code == "CN":
         return _fetch_alerts_cma(lat, lng, lang=lang)
     slug = _METEOALARM_SLUGS.get(country_code)
@@ -696,6 +703,98 @@ def _fetch_alerts_jma(lat, lng, lang="en"):
             "url": "https://www.jma.go.jp/bosai/warning/",
         })
 
+    write_cache(cache_file, alerts)
+    return alerts
+
+
+# ---------------------------------------------------------------------------
+# HKO (Hong Kong Observatory)
+# ---------------------------------------------------------------------------
+
+# Warning type -> (English event name, severity)
+# WRAIN and WTCSGNL have sub-codes; handled via _HKO_RAIN_SEV / _HKO_TC_SEV.
+_HKO_WARNING_INFO = {
+    "WFIRE":  ("Fire Danger Warning",                    "Moderate"),
+    "WFROST": ("Frost Warning",                          "Minor"),
+    "WHOT":   ("Very Hot Weather Warning",               "Minor"),
+    "WCOLD":  ("Cold Weather Warning",                   "Minor"),
+    "WMSGNL": ("Strong Monsoon Signal",                  "Moderate"),
+    "WRAIN":  ("Rainstorm Warning",                      "Moderate"),
+    "WFNTSA": ("Special Announcement on Flooding (NT)",  "Moderate"),
+    "WL":     ("Landslip Warning",                       "Moderate"),
+    "WTCSGNL":("Tropical Cyclone Warning Signal",        "Moderate"),
+    "WTMW":   ("Tsunami Warning",                        "Extreme"),
+    "WTS":    ("Thunderstorm Warning",                   "Minor"),
+}
+
+# WRAIN sub-code -> severity (WRAINB > WRAINR > WRAINA)
+_HKO_RAIN_SEV = {"WRAINB": "Severe", "WRAINR": "Moderate", "WRAINA": "Minor"}
+
+# WTCSGNL sub-code -> severity (TC10 > TC9 > TC8* > TC3 > TC1)
+_HKO_TC_SEV = {
+    "TC10": "Extreme", "TC9": "Extreme",
+    "TC8NE": "Severe", "TC8SE": "Severe", "TC8NW": "Severe", "TC8SW": "Severe",
+    "TC8": "Severe",
+    "TC3": "Moderate", "TC1": "Minor",
+}
+
+
+def _parse_hko_warnsum(data):
+    """Parse HKO warnsum JSON dict into normalised alert list."""
+    alerts = []
+    for key, info in _HKO_WARNING_INFO.items():
+        entry = data.get(key)
+        if not entry:
+            continue
+        if entry.get("actionCode") == "CANCEL":
+            continue
+
+        base_event, base_sev = info
+        code = entry.get("code", key)
+
+        # Refine severity for WRAIN and WTCSGNL based on their sub-code
+        if key == "WRAIN":
+            severity = _HKO_RAIN_SEV.get(code, base_sev)
+            event = entry.get("name") or f"Rainstorm Warning ({code})"
+        elif key == "WTCSGNL":
+            severity = _HKO_TC_SEV.get(code, base_sev)
+            event = entry.get("name") or f"Tropical Cyclone Warning Signal ({code})"
+        else:
+            severity = base_sev
+            event = entry.get("name") or base_event
+
+        # WFIRE: Yellow < Red
+        if key == "WFIRE" and code == "WFIRER":
+            severity = "Severe"
+
+        alerts.append({
+            "event": event,
+            "headline": event,
+            "description": "",
+            "effective": entry.get("issueTime", ""),
+            "expires": entry.get("expireTime", ""),
+            "severity": severity,
+            "url": "https://www.hko.gov.hk/en/detail.htm",
+        })
+
+    severity_order = {"Extreme": 0, "Severe": 1, "Moderate": 2, "Minor": 3}
+    alerts.sort(key=lambda a: severity_order.get(a["severity"], 3))
+    return alerts
+
+
+def _fetch_alerts_hko():
+    """Fetch active HKO weather warnings (Hong Kong). Cached 10min."""
+    cache_file = CACHE_DIR / "alerts_hk.json"
+    url = "https://data.weather.gov.hk/weatherAPI/opendata/weather.php?dataType=warnsum&lang=en"
+    data = fetch_json_cached(
+        cache_file, 600, url,
+        headers={"User-Agent": USER_AGENT},
+        timeout=10, fallback=[],
+    )
+    if isinstance(data, list):
+        return data
+
+    alerts = _parse_hko_warnsum(data)
     write_cache(cache_file, alerts)
     return alerts
 

--- a/src/linecast/tides.py
+++ b/src/linecast/tides.py
@@ -56,6 +56,11 @@ from linecast._tides_qld import (
     fetch_tides_range_qld, fetch_hilo_range_qld, fetch_y_range_qld,
     _fetch_all_stations_qld,
 )
+from linecast._tides_hko import (
+    find_nearest_station_hko, fetch_station_metadata_hko,
+    fetch_tides_range_hko, fetch_hilo_range_hko, fetch_y_range_hko,
+    _fetch_all_stations_hko,
+)
 from linecast._tides_tidecheck import (
     is_available as _tidecheck_available,
     find_nearest_station_tidecheck,
@@ -330,6 +335,15 @@ def _find_matching_stations(query, cli_location=None):
                 "lat": s.get("lat"), "lng": s.get("lng"),
             })
 
+    for s in (_fetch_all_stations_hko() or []):
+        name = s.get("name", "")
+        haystack = f"{name} hong kong hk".lower()
+        if all(t in haystack for t in tokens):
+            candidates.append({
+                "source": "hko", "id": s["id"], "name": name,
+                "lat": s.get("lat"), "lng": s.get("lng"),
+            })
+
     # TideCheck's server-side search returns coordinates too, so its hits
     # join the pool before the distance sort like any other provider's.
     if _tidecheck_available() and tokens:
@@ -377,7 +391,7 @@ def _search_stations(query, metric=False, limit=20, cli_location=None):
         print("Nearest tide stations:")
 
     source_tags = {"chs": " (Canada)", "qld": " (QLD, Australia)",
-                   "tidecheck": " (TideCheck)"}
+                   "hko": " (HK)", "tidecheck": " (TideCheck)"}
     for c in matches[:limit]:
         left = c["name"] if c["id"] == c["name"] else f"{c['id']}  {c['name']}"
         dist = ""
@@ -996,11 +1010,21 @@ def main():
             if country_code == "CA":
                 source = "chs"
                 station_id, station_name = find_nearest_station_chs(lat, lng)
+            elif country_code == "HK":
+                source = "hko"
+                station_id, station_name = find_nearest_station_hko(lat, lng)
             elif country_code == "AU" and _is_qld_lat_lng(lat, lng):
                 source = "qld"
                 station_id, station_name = find_nearest_station_qld(lat, lng)
             else:
                 station_id, station_name = find_nearest_station(lat, lng)
+
+            # Border/outage fallback: an HKO station may be within 100 nm
+            # even when country_code != "HK" (e.g. Macau, Shenzhen coast).
+            if station_id is None and source != "hko":
+                hko_id, hko_name = find_nearest_station_hko(lat, lng)
+                if hko_id is not None:
+                    station_id, station_name, source = hko_id, hko_name, "hko"
 
             # Border/outage fallback: a NOAA station may be in range even
             # when the regional provider found nothing (e.g. Victoria BC).
@@ -1054,6 +1078,7 @@ def main():
         _metadata_fetchers = {
             "chs": fetch_station_metadata_chs,
             "qld": fetch_station_metadata_qld,
+            "hko": fetch_station_metadata_hko,
             "tidecheck": fetch_station_metadata_tidecheck,
             "openmeteo": fetch_station_metadata_openmeteo,
         }
@@ -1072,6 +1097,7 @@ def main():
         _range_fetchers = {
             "chs": (fetch_tides_range_chs, fetch_hilo_range_chs),
             "qld": (fetch_tides_range_qld, fetch_hilo_range_qld),
+            "hko": (fetch_tides_range_hko, fetch_hilo_range_hko),
             "tidecheck": (fetch_tides_range_tidecheck,
                           fetch_hilo_range_tidecheck),
             "openmeteo": (fetch_tides_range_openmeteo,
@@ -1113,6 +1139,7 @@ def main():
         _y_range_fetchers = {
             "chs": fetch_y_range_chs,
             "qld": fetch_y_range_qld,
+            "hko": fetch_y_range_hko,
             "tidecheck": fetch_y_range_tidecheck,
             "openmeteo": fetch_y_range_openmeteo,
         }

--- a/src/linecast/tides.py
+++ b/src/linecast/tides.py
@@ -59,7 +59,8 @@ from linecast._tides_qld import (
 from linecast._tides_hko import (
     find_nearest_station_hko, fetch_station_metadata_hko,
     fetch_tides_range_hko, fetch_hilo_range_hko, fetch_y_range_hko,
-    _fetch_all_stations_hko,
+    _fetch_all_stations_hko, _STATION_BY_ID as _HKO_STATION_BY_ID,
+    _HOTIDE_TO_HKO as _HOTIDE_TO_HKO, _resolve_id as _hko_resolve_id,
 )
 from linecast._tides_tidecheck import (
     is_available as _tidecheck_available,
@@ -965,7 +966,7 @@ def main():
         # Station: --station flag > TIDE_STATION env var > geolocation
         override = args.station or os.environ.get("TIDE_STATION", "").strip()
 
-        source = "noaa"  # "noaa", "chs", "qld", "tidecheck", or "openmeteo"
+        source = "noaa"  # "noaa", "chs", "qld", "hko", "tidecheck", or "openmeteo"
         if override:
             if _is_openmeteo_station_id(override):
                 source = "openmeteo"
@@ -975,6 +976,12 @@ def main():
                 source = "chs"
                 station_id = override
                 station_name = f"Station {override[:8]}"
+            elif _hko_resolve_id(override) in _HKO_STATION_BY_ID:
+                # Matches an HKO prediction code (CCH, KCT, …) or a legacy
+                # hotide real-time code (chc, ct8, …).
+                source = "hko"
+                station_id = _hko_resolve_id(override)
+                station_name = _HKO_STATION_BY_ID[station_id]["name"]
             elif override.isdigit():
                 station_id = override
                 station_name = f"Station {override}"


### PR DESCRIPTION
Hong Kong is in the category of `country_code == "CN"` but it issues its own weather alerts from the Hong Kong Observatory (HKO), and have a dozen tide stations providing tide data.

Added functions that fetches data from HKO's API and parses them to be compatible with existing pipelines.

For weather, `_fetch_hko_alerts()` is called when `city == 'Hong Kong'`and has higher priority than `country_code == 'CN'`.