### PR TITLE
Alerts for New Zealand and six more MeteoAlarm countries; radar --source flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Notable changes, by release. Notes for the next release collect under **Unreleas
 
 - Weather: Official alerts in New Zealand, from MetService, matched to your spot by each warning's own polygon.
 - Weather: Alerts now also cover Ukraine, Israel, Bosnia and Herzegovina, Moldova, Montenegro, and North Macedonia, through MeteoAlarm.
+- Radar: `--source` pins one frame source — `librewxr`, `rainviewer`, or `iem` — instead of choosing by location, for comparing what each shows over the same spot.
 - Radar: The colour themes drawn in the terminal's own palette — terminal, dusk, ember, ink, marangai — now survive a fallback to RainViewer, instead of dropping to its blue scheme.
 - Location: IP geolocation and place-name search each have a second source now, asked when the usual one doesn't answer.
 - Maps: Street tiles fall back to the OpenStreetMap US Tileservice when OpenFreeMap doesn't answer; the credit line names whichever source drew the map.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable changes, by release. Notes for the next release collect under **Unreleas
 
 ## Unreleased
 
+- Weather: Official alerts in New Zealand, from MetService, matched to your spot by each warning's own polygon.
+- Weather: Alerts now also cover Ukraine, Israel, Bosnia and Herzegovina, Moldova, Montenegro, and North Macedonia, through MeteoAlarm.
 - Radar: The colour themes drawn in the terminal's own palette — terminal, dusk, ember, ink, marangai — now survive a fallback to RainViewer, instead of dropping to its blue scheme.
 - Location: IP geolocation and place-name search each have a second source now, asked when the usual one doesn't answer.
 - Maps: Street tiles fall back to the OpenStreetMap US Tileservice when OpenFreeMap doesn't answer; the credit line names whichever source drew the map.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ linecast radar --layers temp,wind
 linecast radar --layer satellite
 ```
 
+`--source librewxr`, `--source rainviewer`, or `--source iem` pins one frame source instead of routing by location, for comparing what each shows over the same spot.
+
 ![animated radar forecast over Glasgow](https://raw.githubusercontent.com/ashuttl/linecast/main/screenshots/radar.gif)
 
 ### Maps
@@ -303,6 +305,7 @@ The six view commands and `linecast doctor` take `--debug`, which prints one lin
 | `LINECAST_TIDECHECK_PAID` | Set to `1` on a paid TideCheck plan; the request tally then drops the 50-a-day free-tier cap |
 | `LINECAST_LANG` | UI language code: `en`, `fr`, `es`, `de`, `it`, `pt`, `nl`, `pl`, `no`, `sv`, `is`, `da`, `fi`, `ja`, `ko`, `zh`, or `id` |
 | `LINECAST_RADAR_THEME` | Default radar color theme |
+| `LINECAST_RADAR_SOURCE` | Pin the radar frame source: `librewxr`, `rainviewer`, or `iem` |
 | `LINECAST_LIBREWXR_URL` | Base URL of a self-hosted LibreWXR instance |
 | `LINECAST_ICONS` | icon set: `nerd`, `emoji`, or `plain`; overrides the saved icons (default: `nerd` where the terminal bundles the glyphs, `emoji` on other interactive terminals, `plain` when piped) |
 | `LINECAST_COLOR` | `auto`, `truecolor`, `256`, `16`, or `none` |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you'd rather type just `weather` instead of `linecast weather`, you can run `
 
 ### Weather
 
-The weather dashboard combines current conditions, daylight-shaded hourly temperatures, precipitation, daily ranges, air quality, and natural-language comparisons. Official alerts are available across 37 countries and open to their full detail in live mode. In India, air quality is shown on the CPCB's National AQI scale.
+The weather dashboard combines current conditions, daylight-shaded hourly temperatures, precipitation, daily ranges, air quality, and natural-language comparisons. Official alerts are available across 44 countries and open to their full detail in live mode. In India, air quality is shown on the CPCB's National AQI scale.
 
 ![weather dashboard](https://raw.githubusercontent.com/ashuttl/linecast/main/screenshots/weather.png)
 
@@ -324,7 +324,7 @@ Cached data lives in `~/Library/Caches/linecast` on macOS and `~/.cache/linecast
 <summary><strong>Data sources and coverage</strong></summary>
 
 - **Location** — [ipinfo.io](https://ipinfo.io/) for IP geolocation when no location is saved or passed, with [ipwho.is](https://ipwho.is/) and [GeoJS](https://www.geojs.io/) as fallbacks; place names are geocoded by Open-Meteo, with Photon as a fallback.
-- **Weather** — [Open-Meteo](https://open-meteo.com/) for forecasts, geocoding, and air quality. Alerts come from the US National Weather Service, Environment Canada, China Meteorological Administration, DWD via Bright Sky, Hong Kong Observatory, Met Éireann, Japan Meteorological Agency, MET Norway, MeteoAlarm, and SACHET (India's national alert aggregator).
+- **Weather** — [Open-Meteo](https://open-meteo.com/) for forecasts, geocoding, and air quality. Alerts come from the US National Weather Service, Environment Canada, China Meteorological Administration, DWD via Bright Sky, Hong Kong Observatory, Met Éireann, Japan Meteorological Agency, MET Norway, MetService New Zealand, MeteoAlarm, and SACHET (India's national alert aggregator).
 - **Sunshine and Moon** — computed on your device from the astronomical equations; the Moon's face is a vendored grayscale of NASA SVS's [CGI Moon Kit](https://svs.gsfc.nasa.gov/4720) (Lunar Reconnaissance Orbiter, public domain).
 - **Tides** — NOAA CO-OPS, Canadian Hydrographic Service, Queensland Open Data, Hong Kong Observatory, Open-Meteo's tide model as a global fallback, and optionally TideCheck.
 - **Radar** — [LibreWXR](https://librewxr.net/), with NEXRAD via Iowa Environmental Mesonet and RainViewer as fallbacks; warning polygons come from the US National Weather Service via IEM. The basemap is derived from Natural Earth.

--- a/src/linecast/_completion.py
+++ b/src/linecast/_completion.py
@@ -74,6 +74,7 @@ def _value_hints():
         "--layer": ("radar", "satellite"),
         # radar.parse_layers() takes a comma-separated set
         "--layers": ("temp", "wind", "temp,wind"),
+        "--source": ("librewxr", "rainviewer", "iem"),
         "--profile": tuple(PROFILES),
     }
 

--- a/src/linecast/_radar_live.py
+++ b/src/linecast/_radar_live.py
@@ -180,6 +180,15 @@ def main():
               file=sys.stderr)
         sys.exit(2)
 
+    source_arg = (args.source
+                  or os.environ.get("LINECAST_RADAR_SOURCE", "")).strip().lower()
+    if source_arg:
+        if source_arg not in ("librewxr", "rainviewer", "iem"):
+            print('Unknown radar source. Sources: librewxr, rainviewer, iem.',
+                  file=sys.stderr)
+            sys.exit(2)
+        _radar_sources.FORCED_SOURCE = source_arg
+
     # everything from here to the first paint may block on the network
     # (geocoding, the frame index, static-mode frame fetches) — spin
     spin = Spinner(rs("loading", runtime.lang))

--- a/src/linecast/_radar_sources.py
+++ b/src/linecast/_radar_sources.py
@@ -316,11 +316,33 @@ def _utc(epoch):
     return datetime.datetime.fromtimestamp(epoch, datetime.timezone.utc)
 
 
+# Set from radar --source: pins one source instead of routing by
+# location, so what each shows can be compared over the same spot.
+FORCED_SOURCE: str | None = None  # "librewxr" | "rainviewer" | "iem"
+
+
+def _forced_source(n_frames, theme):
+    """The source --source pinned, IEM standing in when it won't answer."""
+    if FORCED_SOURCE != "iem":
+        cls = (LibreWXRSource if FORCED_SOURCE == "librewxr"
+               else RainViewerSource)
+        try:
+            src = cls(theme)
+            if src.current_frames():
+                return src
+        except Exception as exc:
+            log_failure(f"radar/{FORCED_SOURCE}", "pinned source", exc,
+                        fallback="IEM")
+    return IEMSource(n_frames)
+
+
 def get_source(lat: float, lon: float, n_frames: int, theme: str | int | None = None
                ) -> LibreWXRSource | RainViewerSource | IEMSource:
     """Pick the best source for a location, falling back on failure."""
     if theme is None:
         theme = THEMES[DEFAULT_THEME]
+    if FORCED_SOURCE is not None:
+        return _forced_source(n_frames, theme)
     src: LibreWXRSource | RainViewerSource
     try:
         src = LibreWXRSource(theme)

--- a/src/linecast/_runtime.py
+++ b/src/linecast/_runtime.py
@@ -413,6 +413,11 @@ def radar_parser():
                     help="condition layers to show, comma-separated: "
                          "temp (temperature tint), wind (speed/direction "
                          "arrows); press c/w in live mode to toggle")
+    p.add_argument("--source", default=None,
+                    help="pin the frame source instead of routing by "
+                         "location: librewxr, rainviewer, or iem "
+                         "(NEXRAD, US only); for comparing what each "
+                         "shows over the same spot")
     _add_units_flags(p, "metric units: celsius, kilometres",
                      "imperial units: fahrenheit, miles")
     _add_clock_flags(p)

--- a/src/linecast/_weather_sources.py
+++ b/src/linecast/_weather_sources.py
@@ -274,6 +274,8 @@ def fetch_alerts(lat: float, lng: float, country_code: str = "", lang: str = "en
         return _fetch_alerts_cma(lat, lng, lang=lang)
     if country_code == "IN":
         return _fetch_alerts_sachet(lat, lng, lang=lang)
+    if country_code == "NZ":
+        return _fetch_alerts_metservice(lat, lng)
     slug = _METEOALARM_SLUGS.get(country_code)
     if slug:
         return _fetch_alerts_meteoalarm(lat, lng, slug, lang=lang, address=address)
@@ -557,14 +559,18 @@ def _parse_meteireann_dt(s):
 # ISO 3166-1 alpha-2 -> MeteoAlarm feed slug
 # DE, NO, IE excluded — they have dedicated providers above
 _METEOALARM_SLUGS = {
-    "AT": "austria", "BE": "belgium", "BG": "bulgaria", "HR": "croatia",
+    "AT": "austria", "BE": "belgium", "BA": "bosnia-herzegovina",
+    "BG": "bulgaria", "HR": "croatia",
     "CY": "cyprus", "CZ": "czechia", "DK": "denmark", "EE": "estonia",
     "FI": "finland", "FR": "france", "GR": "greece",
-    "HU": "hungary", "IS": "iceland", "IT": "italy",
+    "HU": "hungary", "IS": "iceland", "IL": "israel", "IT": "italy",
     "LV": "latvia", "LT": "lithuania", "LU": "luxembourg", "MT": "malta",
-    "NL": "netherlands", "PL": "poland", "PT": "portugal",
+    "MD": "moldova", "ME": "montenegro",
+    "NL": "netherlands", "MK": "republic-of-north-macedonia",
+    "PL": "poland", "PT": "portugal",
     "RO": "romania", "RS": "serbia", "SK": "slovakia", "SI": "slovenia",
-    "ES": "spain", "SE": "sweden", "CH": "switzerland", "GB": "united-kingdom",
+    "ES": "spain", "SE": "sweden", "CH": "switzerland",
+    "UA": "ukraine", "GB": "united-kingdom",
 }
 
 
@@ -1478,6 +1484,165 @@ def _sachet_alert_from_cap(entry, lang):
         "expires": info.get("expires", ""),
         "severity": severity,
         "url": "https://sachet.ndma.gov.in/",
+    }
+
+
+# ---------------------------------------------------------------------------
+# MetService (New Zealand)
+# ---------------------------------------------------------------------------
+
+_METSERVICE_FEED_URL = "https://alerts.metservice.com/cap/rss"
+_METSERVICE_CAP_URL = "https://alerts.metservice.com/cap/alert?id={identifier}"
+
+# The ColourCode parameter carries MetService's public severity ladder;
+# the CAP severity field stands in when an alert has no colour.
+_METSERVICE_COLORS = {"red": "Extreme", "orange": "Severe", "yellow": "Moderate"}
+
+
+def _fetch_alerts_metservice(lat, lng):
+    """Fetch active MetService warnings (New Zealand). Feed cached 15min.
+
+    The public CAP feed (CC BY 4.0) lists every current watch, warning
+    and advisory as an RSS item pointing at a CAP file, which carries
+    the polygon of the ground it covers, so alerts are kept by
+    point-in-polygon: a road snowfall warning for the Desert Road should
+    not follow a user in Auckland. CAP files are cached per identifier —
+    a MetService update is a new identifier — and swept once their alert
+    leaves the feed.
+    """
+    from xml.etree import ElementTree
+
+    from linecast._http import fetch_bytes_cached
+
+    raw = fetch_bytes_cached(
+        cache_dir("weather") / "alerts_nz_feed.xml", 900,
+        _METSERVICE_FEED_URL, timeout=15)
+    if not raw:
+        return []
+    try:
+        feed = ElementTree.fromstring(raw)
+    except ElementTree.ParseError as exc:
+        log_failure("weather/alerts", "MetService feed parse", exc,
+                    fallback="no alerts")
+        return []
+
+    identifiers = [guid.text.strip() for guid in feed.iter("guid")
+                   if guid.text and guid.text.strip()]
+
+    now = datetime.now(timezone.utc)
+    alerts = []
+    seen = set()
+    for identifier in identifiers[:30]:
+        alert = _metservice_alert_from_cap(identifier, lat, lng)
+        if alert is None:
+            continue
+        expires = _parse_iso_aware(alert["expires"])
+        if expires is not None and expires < now:
+            continue  # the cached feed can outlive an alert by up to 15min
+        dedup_key = (alert["event"], alert["severity"], alert["headline"])
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+        alerts.append(alert)
+
+    severity_order = {"Extreme": 0, "Severe": 1, "Moderate": 2, "Minor": 3}
+    alerts.sort(key=lambda a: severity_order.get(a["severity"], 3))
+
+    _sweep_metservice_cap_files(identifiers)
+    return alerts
+
+
+def _sweep_metservice_cap_files(identifiers):
+    """Drop cached CAP files for alerts no longer in the feed."""
+    live = set(identifiers)
+    try:
+        for path in cache_dir("weather").glob("alerts_nz_cap_*.xml"):
+            if path.stem[len("alerts_nz_cap_"):] not in live:
+                path.unlink(missing_ok=True)
+    except OSError as exc:
+        log_failure("cache", "sweep of MetService CAP files", exc,
+                    fallback="left in place")
+
+
+def _metservice_alert_from_cap(identifier, lat, lng):
+    """One feed item as a normalized alert, or None when it does not
+    apply: the CAP file is out of reach or malformed, the alert is a
+    test or a cancellation, or its polygons say the user is outside the
+    warned ground.
+    """
+    from xml.etree import ElementTree
+
+    from linecast._http import fetch_bytes_cached
+
+    # A shorter timeout than usual: these fetches run one after another,
+    # and a stormy week's worth must not hold the dashboard for long.
+    raw = fetch_bytes_cached(
+        cache_dir("weather") / f"alerts_nz_cap_{identifier}.xml", None,
+        _METSERVICE_CAP_URL.format(identifier=identifier), timeout=6)
+    if not raw:
+        return None
+    try:
+        root = ElementTree.fromstring(raw)
+    except ElementTree.ParseError as exc:
+        log_failure("weather/alerts", f"CAP parse of {identifier}", exc,
+                    fallback="skipped")
+        return None
+
+    def _local(tag):
+        return tag.rsplit("}", 1)[-1]
+
+    status = msg_type = ""
+    info_el = None
+    for child in root:
+        tag = _local(child.tag)
+        if tag == "status":
+            status = (child.text or "").strip()
+        elif tag == "msgType":
+            msg_type = (child.text or "").strip()
+        elif tag == "info" and info_el is None:
+            info_el = child
+    if status != "Actual" or msg_type == "Cancel" or info_el is None:
+        return None
+
+    info = {}
+    colour = ""
+    rings = []
+    for child in info_el:
+        tag = _local(child.tag)
+        if tag in ("event", "severity", "headline", "description",
+                   "effective", "onset", "expires", "web"):
+            info[tag] = (child.text or "").strip()
+        elif tag == "parameter":
+            fields = {_local(c.tag): (c.text or "").strip() for c in child}
+            if fields.get("valueName") == "ColourCode":
+                colour = fields.get("value", "").lower()
+        elif tag == "area":
+            polygons = [(c.text or "") for c in child
+                        if _local(c.tag) == "polygon"]
+            rings.extend(_cap_polygons({"polygon": polygons}))
+
+    # The polygon is the warning's own account of the ground it covers;
+    # a CAP file without one (rare) is taken as nationwide.
+    if rings and not any(_point_in_ring(lat, lng, ring) for ring in rings):
+        return None
+
+    headline = " ".join(info.get("headline", "").split())
+    event = headline or info.get("event", "").capitalize()
+    if not event:
+        return None
+    severity = _METSERVICE_COLORS.get(colour, "")
+    if not severity:
+        severity = info.get("severity", "").capitalize()
+        if severity not in ("Extreme", "Severe", "Moderate", "Minor"):
+            severity = "Moderate"
+    return {
+        "event": event,
+        "headline": headline or event,
+        "description": " ".join(info.get("description", "").split()),
+        "effective": info.get("effective") or info.get("onset") or "",
+        "expires": info.get("expires", ""),
+        "severity": severity,
+        "url": info.get("web") or "https://www.metservice.com/warnings/home",
     }
 
 

--- a/src/linecast/doctor.py
+++ b/src/linecast/doctor.py
@@ -75,6 +75,7 @@ def providers():
         ("Open-Meteo archive", "https://archive-api.open-meteo.com/"),
         ("Open-Meteo air quality", "https://air-quality-api.open-meteo.com/"),
         ("NWS alerts", "https://api.weather.gov/"),
+        ("MetService alerts", "https://alerts.metservice.com/"),
         ("ipinfo geolocation", "https://ipinfo.io/"),
         ("ipwho geolocation (fallback)", "https://ipwho.is/"),
         ("GeoJS geolocation (fallback)", "https://get.geojs.io/"),

--- a/src/linecast/radar.py
+++ b/src/linecast/radar.py
@@ -24,7 +24,7 @@ when you type `radar` — the arguments, the source, the keys and the live
 loop — is in _radar_live.
 
 Usage: radar [--location LAT,LNG | PLACE] [--zoom DEG] [--theme NAME]
-             [--layers temp,wind] [--print] [--search CITY]
+             [--layers temp,wind] [--source NAME] [--print] [--search CITY]
 """
 
 import sys

--- a/src/linecast/weather.py
+++ b/src/linecast/weather.py
@@ -7,7 +7,7 @@ Temperature-driven color palette, Nerd Font icons, clean column alignment.
 
 Alerts sourced from NWS (US), Environment Canada (CA), Bright Sky/DWD (DE),
 MET Norway (NO), Met \u00c9ireann (IE), JMA (Japan), CMA (China),
-and MeteoAlarm (30 European countries).
+MetService (NZ), and MeteoAlarm (34 European countries).
 
 Languages: en, fr, es, de, it, pt, nl, pl, no, sv, is, da, fi, ja, ko, zh
 

--- a/tests/fixtures/metservice_cap_desertroad.xml
+++ b/tests/fixtures/metservice_cap_desertroad.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+  <identifier>2.49.0.0.554.0.roadsnow.desertroad.20260831090341521.0</identifier>
+  <sender>https://www.metservice.com</sender>
+  <sent>2026-08-31T21:03:41+12:00</sent>
+  <status>Actual</status>
+  <msgType>Update</msgType>
+  <scope>Public</scope>
+  <references>https://www.metservice.com,2.49.0.0.554.0.roadsnow.desertroad.20260830232733616.0,2026-08-31T11:27:33+12:00</references>
+  <info>
+    <category>Met</category>
+    <event>snow</event>
+    <responseType>Monitor</responseType>
+    <urgency>Future</urgency>
+    <severity>Moderate</severity>
+    <certainty>Likely</certainty>
+    <onset>2026-08-31T23:00:00+12:00</onset>
+    <expires>2035-01-01T06:00:00+13:00</expires>
+    <senderName>Meteorological Service of New Zealand Limited</senderName>
+    <headline>Road Snowfall Warning</headline>
+    <description>Snow showers are expected to affect higher parts of the road late Monday night and early Tuesday morning. Around 1 cm could accumulate above 800 metres. </description>
+    <instruction>Note: A Road Snowfall Warning means there is a likelihood of snow settling on the road during the warning period. People intending to travel on this road should prepare for winter driving conditions. For information on the current status of the road and any closures, see the NZTA website.</instruction>
+    <web>https://metservice.com/warnings/home</web>
+    <parameter>
+      <valueName>NextUpdate</valueName>
+      <value>2026-09-01T11:00:00+12:00</value>
+    </parameter>
+    <parameter>
+      <valueName>ColourCode</valueName>
+      <value>Orange</value>
+    </parameter>
+    <parameter>
+      <valueName>ColourCodeHex</valueName>
+      <value>#FF8918</value>
+    </parameter>
+    <area>
+      <areaDesc>Desert Road (SH1)</areaDesc>
+      <polygon>-39.477,175.666 -39.473,175.666 -39.458,175.674 -39.449,175.676 -39.443,175.679 -39.439,175.679 -39.432,175.683 -39.414,175.686 -39.399,175.696 -39.387,175.706 -39.319,175.727 -39.314,175.730 -39.304,175.739 -39.288,175.738 -39.283,175.739 -39.279,175.742 -39.274,175.737 -39.269,175.735 -39.266,175.731 -39.250,175.734 -39.249,175.733 -39.243,175.725 -39.239,175.724 -39.236,175.726 -39.234,175.730 -39.231,175.733 -39.220,175.732 -39.215,175.735 -39.212,175.740 -39.209,175.745 -39.207,175.748 -39.203,175.754 -39.200,175.754 -39.196,175.752 -39.191,175.755 -39.187,175.755 -39.184,175.757 -39.183,175.756 -39.182,175.756 -39.179,175.760 -39.178,175.766 -39.176,175.767 -39.175,175.764 -39.173,175.763 -39.163,175.766 -39.159,175.767 -39.158,175.764 -39.156,175.763 -39.154,175.765 -39.142,175.770 -39.141,175.772 -39.139,175.778 -39.119,175.798 -39.110,175.804 -39.106,175.806 -39.095,175.807 -39.084,175.805 -39.076,175.807 -39.075,175.808 -39.075,175.810 -39.076,175.811 -39.085,175.809 -39.091,175.811 -39.095,175.812 -39.106,175.810 -39.111,175.808 -39.121,175.802 -39.141,175.782 -39.144,175.774 -39.152,175.770 -39.155,175.772 -39.157,175.770 -39.159,175.771 -39.164,175.771 -39.170,175.768 -39.172,175.768 -39.173,175.770 -39.175,175.771 -39.180,175.771 -39.181,175.769 -39.181,175.766 -39.183,175.768 -39.185,175.767 -39.188,175.759 -39.192,175.760 -39.197,175.757 -39.200,175.759 -39.205,175.759 -39.210,175.751 -39.211,175.748 -39.215,175.743 -39.217,175.739 -39.220,175.737 -39.232,175.737 -39.236,175.734 -39.240,175.729 -39.241,175.729 -39.246,175.737 -39.249,175.738 -39.253,175.738 -39.263,175.736 -39.265,175.735 -39.267,175.738 -39.272,175.741 -39.276,175.746 -39.278,175.747 -39.281,175.746 -39.284,175.744 -39.289,175.743 -39.304,175.743 -39.320,175.731 -39.388,175.711 -39.400,175.700 -39.415,175.691 -39.433,175.687 -39.440,175.684 -39.444,175.684 -39.450,175.681 -39.459,175.678 -39.474,175.671 -39.478,175.671 -39.479,175.669 -39.479,175.668 -39.477,175.666</polygon>
+    </area>
+  </info>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>w0UOQ6Zw9vc1/IBuoVNvWbJ/kYIjrRrO+3D1Ft1qfL4=</DigestValue></Reference></SignedInfo><SignatureValue>HjIVVd7zXABzDz0+jXItbEps7kkRu/UdslYKms1NGOuQeKmzcNeiCqv8ZpwwiCDA9uKA5dzAXRB7&#13;
+iXdvfL99jQFzO77CBvfcyT3UJi2yMWyMLEsuoGIZjLcTwetxQc8E3Knarr9RUs+3eLQa9xZSD26N&#13;
+cizpUKINZeRSfkYYNnWHbf5xhhpW+WddB6YktU9UF0XnptyY/ozBbIlPqEB5D3t/jllFbqMxXnSE&#13;
+7ElkANiQe9zh+tH5IzambhiyaOUglve0FhWL6wR8E4+xSB/r8wKqWJUm50YecVnWxWuaw+ZlTolA&#13;
+qYK0spdYJnIJdjaAiFmnxp53Kax3/12mpsiTMA==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIID+zCCAuOgAwIBAgIEQXDSuTANBgkqhkiG9w0BAQsFADCBrTELMAkGA1UEBhMCTloxEzARBgNV&#13;
+BAgTCldlbGxpbmd0b24xEzARBgNVBAcTCldlbGxpbmd0b24xNjA0BgNVBAoTLU1FVEVPUk9MT0dJ&#13;
+Q0FMIFNFUlZJQ0UgT0YgTkVXIFpFQUxBTkQgTElNSVRFRDEfMB0GA1UECxMWSW5mb3JtYXRpb24g&#13;
+VGVjaG5vbG9neTEbMBkGA1UEAxMSY2FwLm1ldHNlcnZpY2UuY29tMB4XDTI1MTAyMDIyNDU1NloX&#13;
+DTI2MTAyMDIyNDU1Nlowga0xCzAJBgNVBAYTAk5aMRMwEQYDVQQIEwpXZWxsaW5ndG9uMRMwEQYD&#13;
+VQQHEwpXZWxsaW5ndG9uMTYwNAYDVQQKEy1NRVRFT1JPTE9HSUNBTCBTRVJWSUNFIE9GIE5FVyBa&#13;
+RUFMQU5EIExJTUlURUQxHzAdBgNVBAsTFkluZm9ybWF0aW9uIFRlY2hub2xvZ3kxGzAZBgNVBAMT&#13;
+EmNhcC5tZXRzZXJ2aWNlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOtYoScZ&#13;
+w+ucewOrHmJLm0jtfWRqYQzN22od96kr1ruHroKyUWfP9ckX0qaewA51m8gZEC+cms3+U9tFELWL&#13;
+xvMfCw1vqexbyQbudu6jf9BIBx9FpZtxIjVuJL/6bLlqyDJhBH8Dq9A5Z5aK0Wc6GHoBijDH9O1H&#13;
+Z/vZsPVqVoBKVby3vvMeMdDPPomVpYZdRpQy4ApLUsmiYoqiQeEDIb5EQ/HrX2WjK9iuwfp+eOn7&#13;
+Mz5v4b0Kl7PuSzqAzIdyJePiibmhEu+o6MWQOl34qXH4cPo/SJD9lHM0j3ZoAQoIVqEXY2Jg2QJc&#13;
+/zd96n1qXPm+Gp0zeed5G0HCU4epXX0CAwEAAaMhMB8wHQYDVR0OBBYEFKxsISH42wf950TylFDE&#13;
+xkSCqq52MA0GCSqGSIb3DQEBCwUAA4IBAQAjS+EC5034C1JjYxFeej/9E4/0F1lrshbX5dEkKUNy&#13;
+fbSxv6+UeES51P01lUp4qBRMZGLOQJtla1b9haumYxzOg83vw4HIFP1dK71P5bh5RapKBxnGLo7z&#13;
+Xstq1dyBgAC9F6ztgSEMAeLEKImQOmV0Rfzsu9PdiUv7YMU6MIkCMr7Nqz5kqN49Lb1RrneHw2be&#13;
+UyQUUh6GL0SOx19p1NpzDr2uFlEI7UXR6RzrI1fOaceR3q6EhoPy7YGil3VRe/e6OhnHbpOfxUeE&#13;
+xqYPOKJ8bXTA8aBVGIpRz4RAqr8e1KqtrQeMpy8fPkmtJefUeiltRfUdUDOHvCqbgtItoPpQ</X509Certificate></X509Data></KeyInfo></Signature></alert>

--- a/tests/fixtures/metservice_cap_dunedintowaitatihighway.xml
+++ b/tests/fixtures/metservice_cap_dunedintowaitatihighway.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+  <identifier>2.49.0.0.554.0.roadsnow.dunedintowaitatihighway.20260831090341532.0</identifier>
+  <sender>https://www.metservice.com</sender>
+  <sent>2026-08-31T21:03:41+12:00</sent>
+  <status>Actual</status>
+  <msgType>Update</msgType>
+  <scope>Public</scope>
+  <references>https://www.metservice.com,2.49.0.0.554.0.roadsnow.dunedintowaitatihighway.20260830232733616.0,2026-08-31T11:27:33+12:00</references>
+  <info>
+    <category>Met</category>
+    <event>snow</event>
+    <responseType>Monitor</responseType>
+    <urgency>Immediate</urgency>
+    <severity>Moderate</severity>
+    <certainty>Likely</certainty>
+    <onset>2026-08-31T20:00:00+12:00</onset>
+    <expires>2035-01-01T06:00:00+13:00</expires>
+    <senderName>Meteorological Service of New Zealand Limited</senderName>
+    <headline>Road Snowfall Warning</headline>
+    <description>Snow showers may continue about the road overnight Monday into early Tuesday morning. 1 to 3 cm may accumulate about the highest part of the road with lesser amounts down to 100 metres.</description>
+    <instruction>Note: A Road Snowfall Warning means there is a likelihood of snow settling on the road during the warning period. People intending to travel on this road should prepare for winter driving conditions. For information on the current status of the road and any closures, see the NZTA website.</instruction>
+    <web>https://metservice.com/warnings/home</web>
+    <parameter>
+      <valueName>NextUpdate</valueName>
+      <value>2026-09-01T11:00:00+12:00</value>
+    </parameter>
+    <parameter>
+      <valueName>ColourCode</valueName>
+      <value>Orange</value>
+    </parameter>
+    <parameter>
+      <valueName>ColourCodeHex</valueName>
+      <value>#FF8918</value>
+    </parameter>
+    <area>
+      <areaDesc>Dunedin to Waitati Highway (SH1)</areaDesc>
+      <polygon>-45.834,170.507 -45.836,170.511 -45.837,170.517 -45.840,170.519 -45.842,170.518 -45.848,170.512 -45.852,170.511 -45.853,170.509 -45.853,170.507 -45.851,170.506 -45.847,170.507 -45.840,170.514 -45.840,170.509 -45.838,170.504 -45.836,170.502 -45.834,170.501 -45.829,170.505 -45.825,170.515 -45.817,170.514 -45.809,170.518 -45.803,170.512 -45.801,170.512 -45.795,170.517 -45.794,170.520 -45.792,170.524 -45.789,170.542 -45.787,170.548 -45.784,170.550 -45.774,170.551 -45.768,170.556 -45.757,170.555 -45.754,170.556 -45.752,170.558 -45.746,170.567 -45.746,170.570 -45.746,170.571 -45.748,170.571 -45.754,170.562 -45.757,170.561 -45.769,170.561 -45.775,170.556 -45.787,170.554 -45.790,170.550 -45.792,170.545 -45.796,170.525 -45.798,170.521 -45.802,170.518 -45.808,170.523 -45.817,170.520 -45.825,170.520 -45.828,170.518 -45.831,170.509 -45.834,170.507</polygon>
+    </area>
+  </info>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>XdbikORBUSQ/g7ZzhN21/3IK8XjFODQYXYKePedBWkA=</DigestValue></Reference></SignedInfo><SignatureValue>oQ7z8ouHlYyw02n0t1jY9Lm0q8/1FTI86qmiVtnwa9JoHzcEaIElKqzcPpVKIwc8JIG/pk2Pmhw/&#13;
+jQQukWt1mvj/tbQMIURYoUDM1H8HnKVYwh9sfVQzy4usrXV/DDNPbuCgSEAIpsAD7eukUhqA93wP&#13;
+oKGcvddDP7i35AtGtdbxHoBj//3fwYEXg2PBnKNkuDwtVcyeNX+nu0xCcTyxO4NMfUH63Pnv0beQ&#13;
+p2vZmoB34KMiY3+IXkzNZX43FqZJW7ktAoDPoQqyFwgDCTjRJmqZoge4ryd/n4Aup+j8IZhsyb/7&#13;
+3ke1ajjr2byBVEzRCfrU+i/JdLQ00dQsZEFCJA==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIID+zCCAuOgAwIBAgIEQXDSuTANBgkqhkiG9w0BAQsFADCBrTELMAkGA1UEBhMCTloxEzARBgNV&#13;
+BAgTCldlbGxpbmd0b24xEzARBgNVBAcTCldlbGxpbmd0b24xNjA0BgNVBAoTLU1FVEVPUk9MT0dJ&#13;
+Q0FMIFNFUlZJQ0UgT0YgTkVXIFpFQUxBTkQgTElNSVRFRDEfMB0GA1UECxMWSW5mb3JtYXRpb24g&#13;
+VGVjaG5vbG9neTEbMBkGA1UEAxMSY2FwLm1ldHNlcnZpY2UuY29tMB4XDTI1MTAyMDIyNDU1NloX&#13;
+DTI2MTAyMDIyNDU1Nlowga0xCzAJBgNVBAYTAk5aMRMwEQYDVQQIEwpXZWxsaW5ndG9uMRMwEQYD&#13;
+VQQHEwpXZWxsaW5ndG9uMTYwNAYDVQQKEy1NRVRFT1JPTE9HSUNBTCBTRVJWSUNFIE9GIE5FVyBa&#13;
+RUFMQU5EIExJTUlURUQxHzAdBgNVBAsTFkluZm9ybWF0aW9uIFRlY2hub2xvZ3kxGzAZBgNVBAMT&#13;
+EmNhcC5tZXRzZXJ2aWNlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOtYoScZ&#13;
+w+ucewOrHmJLm0jtfWRqYQzN22od96kr1ruHroKyUWfP9ckX0qaewA51m8gZEC+cms3+U9tFELWL&#13;
+xvMfCw1vqexbyQbudu6jf9BIBx9FpZtxIjVuJL/6bLlqyDJhBH8Dq9A5Z5aK0Wc6GHoBijDH9O1H&#13;
+Z/vZsPVqVoBKVby3vvMeMdDPPomVpYZdRpQy4ApLUsmiYoqiQeEDIb5EQ/HrX2WjK9iuwfp+eOn7&#13;
+Mz5v4b0Kl7PuSzqAzIdyJePiibmhEu+o6MWQOl34qXH4cPo/SJD9lHM0j3ZoAQoIVqEXY2Jg2QJc&#13;
+/zd96n1qXPm+Gp0zeed5G0HCU4epXX0CAwEAAaMhMB8wHQYDVR0OBBYEFKxsISH42wf950TylFDE&#13;
+xkSCqq52MA0GCSqGSIb3DQEBCwUAA4IBAQAjS+EC5034C1JjYxFeej/9E4/0F1lrshbX5dEkKUNy&#13;
+fbSxv6+UeES51P01lUp4qBRMZGLOQJtla1b9haumYxzOg83vw4HIFP1dK71P5bh5RapKBxnGLo7z&#13;
+Xstq1dyBgAC9F6ztgSEMAeLEKImQOmV0Rfzsu9PdiUv7YMU6MIkCMr7Nqz5kqN49Lb1RrneHw2be&#13;
+UyQUUh6GL0SOx19p1NpzDr2uFlEI7UXR6RzrI1fOaceR3q6EhoPy7YGil3VRe/e6OhnHbpOfxUeE&#13;
+xqYPOKJ8bXTA8aBVGIpRz4RAqr8e1KqtrQeMpy8fPkmtJefUeiltRfUdUDOHvCqbgtItoPpQ</X509Certificate></X509Data></KeyInfo></Signature></alert>

--- a/tests/fixtures/metservice_rss.xml
+++ b/tests/fixtures/metservice_rss.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+  <channel>
+    <title>Metservice Public CAP Alerts</title>
+    <link>https://www.metservice.com</link>
+    <description>Current Watches, Warnings and Advisories for New Zealand issued by MetService</description>
+    <copyright>Copyright Meteorological Service of New Zealand Limited, 2026. Licensed under Creative Commons BY 4.0.</copyright>
+    <pubDate>Mon, 31 Aug 2026 23:21:28 +1200</pubDate>
+    <item>
+      <title>Road Snowfall Warning</title>
+      <guid>2.49.0.0.554.0.roadsnow.desertroad.20260831090341521.0</guid>
+      <category>Met</category>
+      <pubDate>Mon, 31 Aug 2026 21:03:41 +1200</pubDate>
+      <description>Snow showers are expected to affect higher parts of the road late Monday night and early Tuesday morning. Around 1 cm could accumulate above 800 metres. </description>
+      <link>https://alerts.metservice.com/cap/alert?id=2.49.0.0.554.0.roadsnow.desertroad.20260831090341521.0</link>
+    </item>
+    <item>
+      <title>Road Snowfall Warning</title>
+      <guid>2.49.0.0.554.0.roadsnow.dunedintowaitatihighway.20260831090341532.0</guid>
+      <category>Met</category>
+      <pubDate>Mon, 31 Aug 2026 21:03:41 +1200</pubDate>
+      <description>Snow showers may continue about the road overnight Monday into early Tuesday morning. 1 to 3 cm may accumulate about the highest part of the road with lesser amounts down to 100 metres.</description>
+      <link>https://alerts.metservice.com/cap/alert?id=2.49.0.0.554.0.roadsnow.dunedintowaitatihighway.20260831090341532.0</link>
+    </item>
+  </channel>
+</rss>

--- a/tests/test_radar_sources.py
+++ b/tests/test_radar_sources.py
@@ -199,6 +199,31 @@ class TestGetSource:
             tiles.fetch_index = original
         assert isinstance(src, IEMSource)
 
+    def _forced(self, name, by_provider, lat=51.5, lon=-0.12):
+        original = self._patch(by_provider)
+        sources.FORCED_SOURCE = name
+        try:
+            return get_source(lat, lon, 5)
+        finally:
+            sources.FORCED_SOURCE = None
+            tiles.fetch_index = original
+
+    def test_forced_rainviewer_wins_over_librewxr(self):
+        src = self._forced("rainviewer", {"rv": _INDEX, "lwxr": _INDEX})
+        assert isinstance(src, RainViewerSource)
+
+    def test_forced_librewxr_is_librewxr(self):
+        src = self._forced("librewxr", {"rv": _INDEX, "lwxr": _INDEX})
+        assert isinstance(src, LibreWXRSource)
+
+    def test_forced_iem_skips_the_tile_sources(self):
+        src = self._forced("iem", {"rv": _INDEX, "lwxr": _INDEX})
+        assert isinstance(src, IEMSource)
+
+    def test_forced_source_still_falls_back_on_failure(self):
+        src = self._forced("rainviewer", {})
+        assert isinstance(src, IEMSource)
+
 
 class TestTileSourceFrames:
     def _stub(self, index):

--- a/tests/test_weather_parsing.py
+++ b/tests/test_weather_parsing.py
@@ -427,6 +427,27 @@ class TestAlertProviderRouting:
         mock_fn.assert_called_once_with(28.61, 77.21, lang="en")
         assert result == [{"event": "x"}]
 
+    def test_routes_nz_to_metservice(self):
+        from linecast._weather_sources import fetch_alerts
+        with patch("linecast._weather_sources._fetch_alerts_metservice",
+                   return_value=[{"event": "x"}]) as mock_fn:
+            result = fetch_alerts(-41.29, 174.78, country_code="NZ")
+        mock_fn.assert_called_once_with(-41.29, 174.78)
+        assert result == [{"event": "x"}]
+
+    def test_routes_newer_meteoalarm_members(self):
+        from linecast._weather_sources import fetch_alerts
+        for code, slug, lat, lng in (
+                ("UA", "ukraine", 50.45, 30.52),
+                ("BA", "bosnia-herzegovina", 43.86, 18.41),
+                ("MK", "republic-of-north-macedonia", 41.99, 21.43)):
+            with patch("linecast._weather_sources._fetch_alerts_meteoalarm",
+                       return_value=[{"event": "x"}]) as mock_fn:
+                result = fetch_alerts(lat, lng, country_code=code)
+            mock_fn.assert_called_once_with(lat, lng, slug, lang="en",
+                                            address=None)
+            assert result == [{"event": "x"}]
+
     def test_unknown_country_returns_empty(self):
         from linecast._weather_sources import fetch_alerts
         assert fetch_alerts(0, 0, country_code="XX") == []
@@ -1041,3 +1062,63 @@ class TestIndiaAqi:
         header = render_header(forecast, 120, "Delhi", aqi_data=aqi_data)
         assert "438" in header  # the CPCB number, not us_aqi's 150
         assert "Severe" in header  # the CPCB category, marking the scale
+
+
+# ---------------------------------------------------------------------------
+# MetService alerts (New Zealand)
+# ---------------------------------------------------------------------------
+
+def _metservice_from_fixtures(cache_file, max_age, url, **kwargs):
+    """Serve the feed and CAP fixtures the way fetch_bytes_cached would."""
+    if url.endswith("/cap/rss"):
+        return (FIXTURES / "metservice_rss.xml").read_bytes()
+    for name in ("desertroad", "dunedintowaitatihighway"):
+        if name in url:
+            return (FIXTURES / f"metservice_cap_{name}.xml").read_bytes()
+    return None
+
+
+class TestMetServiceAlerts:
+    """Parse a MetService CAP feed snapshot with its CAP files."""
+
+    def _alerts(self, lat, lng, side_effect=_metservice_from_fixtures):
+        from linecast._weather_sources import _fetch_alerts_metservice
+        with patch("linecast._http.fetch_bytes_cached",
+                   side_effect=side_effect):
+            return _fetch_alerts_metservice(lat, lng)
+
+    def test_desert_road_gets_its_warning(self):
+        alerts = self._alerts(-39.379, 175.709)
+        assert len(alerts) == 1
+        a = alerts[0]
+        assert a["event"] == "Road Snowfall Warning"
+        assert a["severity"] == "Severe"  # ColourCode Orange
+        assert "Snow showers are expected" in a["description"]
+        for key in ("event", "headline", "description", "effective",
+                    "expires", "severity", "url"):
+            assert key in a
+
+    def test_dunedin_gets_the_other_warning(self):
+        alerts = self._alerts(-45.765, 170.56)
+        assert len(alerts) == 1
+        assert "Snow showers may continue" in alerts[0]["description"]
+
+    def test_auckland_is_outside_both_polygons(self):
+        assert self._alerts(-36.85, 174.76) == []
+
+    def test_expired_alert_dropped(self):
+        def expired(cache_file, max_age, url, **kwargs):
+            raw = _metservice_from_fixtures(cache_file, max_age, url)
+            return raw and raw.replace(b"2035-01-01", b"2020-01-01")
+        assert self._alerts(-39.379, 175.709, side_effect=expired) == []
+
+    def test_cancelled_alert_dropped(self):
+        def cancelled(cache_file, max_age, url, **kwargs):
+            raw = _metservice_from_fixtures(cache_file, max_age, url)
+            return raw and raw.replace(b"<msgType>Update</msgType>",
+                                       b"<msgType>Cancel</msgType>")
+        assert self._alerts(-39.379, 175.709, side_effect=cancelled) == []
+
+    def test_unreachable_feed_is_no_alerts(self):
+        assert self._alerts(-39.379, 175.709,
+                            side_effect=lambda *a, **k: None) == []


### PR DESCRIPTION
Two coverage additions and one comparison tool, from the local-provider-coverage review.

## Weather alerts

- **New Zealand** — a new provider reads MetService's public CAP feed (CC BY 4.0, no key). Each RSS item's CAP file carries the polygon of the ground it covers, so alerts are kept by point-in-polygon, following the SACHET pattern: CAP files cached per identifier (an update is a new identifier) and swept once their alert leaves the feed. Severity follows the ColourCode parameter (red/orange/yellow → Extreme/Severe/Moderate), with the CAP severity field behind it. Verified against the live feed: today's Desert Road snowfall warning shows from Desert Road coordinates and not from Auckland.
- **MeteoAlarm** — the slug table gains Ukraine, Israel, Bosnia and Herzegovina, Moldova, Montenegro, and North Macedonia. All six feeds answer today (North Macedonia under `republic-of-north-macedonia`); they were live members the router never reached. Alert coverage goes from 37 countries to 44.

## Radar

- `--source librewxr|rainviewer|iem` (and `LINECAST_RADAR_SOURCE`) pins one frame source instead of routing by location, so what each shows can be compared over the same spot — groundwork for deciding where RainViewer's real radar should stand in for LibreWXR's model (RainViewer has real radar for Australia, NZ, Korea, China, Brazil and more; see the #40 caution about India before switching anywhere). A pinned tile source that won't answer still falls back to IEM, and the footer names whichever source actually drew the frames. Shell completion knows the values.

## Notes

- **Australia is deliberately absent.** The keyless api.weather.bom.gov.au responses carry a copyright notice reading "You must not use, copy or share it", and BOM's website 403s non-browser agents, pointing at their anonymous FTP channel as the sanctioned route. FTP needs its own plumbing and a decision, so it's left out rather than shipped against BOM's stated terms.
- Tests: fixtures are real captured feed/CAP responses (expiry pinned to 2035, the SACHET convention), plus routing tests, polygon in/out, expired, cancelled, and unreachable-feed cases, and forced-source tests for the radar routing. Full suite passes: 2095 passed, 12 skipped.
- `linecast doctor` probes alerts.metservice.com alongside the other alert hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPWuq7Zn4G49NdgdN7n2QK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPWuq7Zn4G49NdgdN7n2QK)_