### PR TITLE
Weather: Swiss alerts fit under the feed cap, and the region file gets its contract tested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Notable changes, by release. Notes for the next release collect under **Unreleas
 
 ## Unreleased
 
+- Tides: The Indonesian view now names the wave and swell lines in Indonesian (gelombang, alun) instead of English.
 - Weather: Alerts in Bulgaria, Romania, France, Hungary, Belgium, North Macedonia, and Czechia now match the ground they cover, as the rest of Europe's do. Those feeds name a warning's region by a code linecast could not place until now; with them, every European feed is matched by geometry.
 - Thai is the eighteenth language: `--lang th` puts the whole app — weather, sunshine, moon, tides, radar, and maps — in Thai.
 - Moon: `--lang th` (or `--calendar thai`) follows the Thai lunar calendar: the waxing or waning day in Thai numerals — แรม ๔ ค่ำ เดือน ๙ — with the year's animal, the next วันพระ, and the coming festival, มาฆบูชา through ลอยกระทง, computed by the traditional Suriyayart arithmetic and checked against the official holy days of 2023–2026.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Notable changes, by release. Notes for the next release collect under **Unreleas
 
 ## Unreleased
 
+- Weather: Alerts in Switzerland show again. The Swiss feed draws every warning's outline and had grown past the size linecast would read, so the board showed a quiet day.
 - Tides: The Indonesian view now names the wave and swell lines in Indonesian (gelombang, alun) instead of English.
 - Weather: Alerts in Bulgaria, Romania, France, Hungary, Belgium, North Macedonia, and Czechia now match the ground they cover, as the rest of Europe's do. Those feeds name a warning's region by a code linecast could not place until now; with them, every European feed is matched by geometry.
 - Thai is the eighteenth language: `--lang th` puts the whole app — weather, sunshine, moon, tides, radar, and maps — in Thai.

--- a/src/linecast/_tides_i18n.py
+++ b/src/linecast/_tides_i18n.py
@@ -90,6 +90,8 @@ _TIDES_STRINGS = {
     },
     "id": {
         "space_to_now": "spasi untuk kembali ke sekarang",
+        "waves": "Gelombang",
+        "swell": "Alun",
     },
 }
 

--- a/src/linecast/_weather_sources.py
+++ b/src/linecast/_weather_sources.py
@@ -597,6 +597,13 @@ _METEOALARM_SLUGS = {
     "UA": "ukraine", "GB": "united-kingdom",
 }
 
+# A feed is the whole country's, and one that draws every warning's
+# outline runs big: Switzerland's was 9.4 MB on 2026-09-02, past the
+# 8 MiB fetch_json allows, and the refusal read as a quiet day. The cap
+# stays, since a runaway server is still the thing it is for, but high
+# enough that a stormy day in a polygon-filing country gets through.
+_METEOALARM_FEED_BYTES = 32 * 1024 * 1024
+
 
 def _fetch_alerts_meteoalarm(lat, lng, slug, lang="en", address=None):
     """Fetch MeteoAlarm warnings for a European country. Cached 15min.
@@ -608,9 +615,10 @@ def _fetch_alerts_meteoalarm(lat, lng, slug, lang="en", address=None):
         "weather", f"alerts_eu_{slug}_{location_cache_key(lat, lng)}_{lang}.json")
     url = f"https://feeds.meteoalarm.org/api/v1/warnings/feeds-{slug}"
     data = fetch_json_cached(
-        cache_file, 900, url,
-        headers={"Accept": "application/json"},
-        timeout=15, fallback=[],
+        cache_file, 900, url, timeout=15, fallback=[],
+        fetch=lambda url, timeout: fetch_json(
+            url, headers={"Accept": "application/json"}, timeout=timeout,
+            limit=_METEOALARM_FEED_BYTES),
     )
     if isinstance(data, list):
         return data

--- a/tests/test_live_providers.py
+++ b/tests/test_live_providers.py
@@ -189,6 +189,43 @@ def test_alerts(failures, country, point, provider):
 
 
 # ---------------------------------------------------------------------------
+# MeteoAlarm: every feed's warnings can still be placed
+# ---------------------------------------------------------------------------
+# A warning with no CAP polygon is matched by a geocode against the
+# region file baked into the wheel, and that file only knows the codes
+# the feeds filed when it was baked. A feed that moves to a new NUTS
+# edition, or starts filing a code type the file lacks, would fall back
+# to matching on the area name without a word; this asks every feed,
+# every day, whether the file still places all of it.
+from linecast._weather_sources import _METEOALARM_SLUGS  # noqa: E402
+
+
+@pytest.mark.parametrize("country, slug", sorted(_METEOALARM_SLUGS.items()),
+                         ids=sorted(_METEOALARM_SLUGS))
+def test_meteoalarm_feed_is_placed(failures, country, slug):
+    from linecast._http import fetch_json
+    from linecast._weather_sources import (_METEOALARM_FEED_BYTES, _cap_polygons,
+                                           _region_keys)
+    # under the runtime's own cap, so a feed outgrowing it fails here too
+    feed = fetch_json(f"https://feeds.meteoalarm.org/api/v1/warnings/feeds-{slug}",
+                      headers={"Accept": "application/json"}, timeout=15,
+                      limit=_METEOALARM_FEED_BYTES)
+    assert failures() == []
+    unplaced = {}
+    for w in feed.get("warnings", []):
+        for info in w.get("alert", {}).get("info", []):
+            for area in info.get("area", []):
+                if _cap_polygons(area) or _region_keys([area]):
+                    continue
+                codes = " ".join(f"{g.get('valueName')}/{g.get('value')}"
+                                 for g in area.get("geocode") or []) or "(no geocode)"
+                unplaced[codes] = unplaced.get(codes, 0) + 1
+    assert not unplaced, (
+        f"{country}: {sum(unplaced.values())} areas the region file cannot place: "
+        + "; ".join(f"{n} x [{codes}]" for codes, n in sorted(unplaced.items())[:12]))
+
+
+# ---------------------------------------------------------------------------
 # Tides
 # ---------------------------------------------------------------------------
 def _check_hilo(hilo):

--- a/tests/test_meteoalarm_regions.py
+++ b/tests/test_meteoalarm_regions.py
@@ -1,0 +1,281 @@
+"""The MeteoAlarm region file: what the bake script writes, the runtime
+reads; the loader fails soft; and the shipped file holds together.
+
+tests/test_weather_parsing.py asks the shipped file about real places.
+This file is about the contract around it: scripts/build_meteoalarm_regions.py
+and linecast._meteoalarm_regions agree on the format, a missing or
+broken file costs nobody an alert, and the file that ships carries
+every country the runtime will ask it about.
+
+linecast is imported inside fixtures and tests, never at module level:
+tests/test_oneline.py re-imports the package mid-session, and a module
+object bound at collection time would be the stale one.
+"""
+
+import gzip
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+BAKE_SCRIPT = Path(__file__).parent.parent / "scripts" / "build_meteoalarm_regions.py"
+
+
+@pytest.fixture(scope="module")
+def bake():
+    """The bake script as a module. The sdist leaves scripts/ out."""
+    if not BAKE_SCRIPT.exists():
+        pytest.skip("scripts/build_meteoalarm_regions.py is not in this tree")
+    spec = importlib.util.spec_from_file_location("build_meteoalarm_regions", BAKE_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mr():
+    """The runtime module, with its cache left the way it was found."""
+    from linecast import _meteoalarm_regions
+    saved = (_meteoalarm_regions._REGIONS, _meteoalarm_regions._CODES)
+    _meteoalarm_regions._REGIONS, _meteoalarm_regions._CODES = None, None
+    yield _meteoalarm_regions
+    _meteoalarm_regions._REGIONS, _meteoalarm_regions._CODES = saved
+
+
+def _square(lat0, lat1, lng0, lng1):
+    """A closed GeoJSON ring, [lng, lat] order, around a lat/lng box."""
+    return [[lng0, lat0], [lng1, lat0], [lng1, lat1], [lng0, lat1], [lng0, lat0]]
+
+
+# Two regions the way the bake script sees them: a plain polygon, and a
+# multipolygon whose first part has a hole.
+GEOMETRY = [
+    ("AA001", {"type": "Polygon", "coordinates": [_square(50, 51, 10, 11)]}),
+    ("NUTS3/AA001", {"type": "MultiPolygon", "coordinates": [
+        [_square(52, 53, 10, 11), _square(52.2, 52.4, 10.2, 10.4)],
+        [_square(54, 55, 12, 13)],
+    ]}),
+]
+
+
+class TestRoundTrip:
+    """pack() in the script and _parse() in the runtime are one format."""
+
+    def test_packed_regions_parse_back(self, bake, mr):
+        raw, npts = bake.pack(GEOMETRY)
+        regions = mr._parse(raw)
+        assert [key for key, _, _ in regions] == ["AA001", "NUTS3/AA001"]
+        assert npts == 4 + 4 + 4 + 4
+        _, bbox, polygons = regions[1]
+        assert bbox == pytest.approx((52.0, 55.0, 10.0, 13.0))
+        assert len(polygons) == 2
+        outer, holes = polygons[0]
+        assert len(outer) == 4 and len(holes) == 1
+        assert polygons[1][1] == []
+
+    def test_the_hole_and_the_second_part_survive(self, bake, mr):
+        raw, _ = bake.pack(GEOMETRY)
+        mr._REGIONS = mr._parse(raw)
+        assert mr.regions_at(50.5, 10.5) == {"AA001"}
+        assert mr.regions_at(52.5, 10.5) == {"NUTS3/AA001"}
+        assert mr.regions_at(52.3, 10.3) == set()      # inside the hole
+        assert mr.regions_at(54.5, 12.5) == {"NUTS3/AA001"}
+        assert mr.known("NUTS3/AA001") and not mr.known("AA002")
+
+    def test_a_baked_file_loads_from_disk(self, bake, mr, tmp_path):
+        raw, _ = bake.pack(GEOMETRY)
+        path = tmp_path / "regions.bin.gz"
+        path.write_bytes(gzip.compress(raw))
+        with patch.object(mr, "_PATH", str(path)):
+            assert mr.regions_at(50.5, 10.5) == {"AA001"}
+
+    def test_coordinates_keep_five_decimals(self, bake, mr):
+        ring = [[10.123456, 50.654321], [11, 50], [11, 51], [10.123456, 50.654321]]
+        raw, _ = bake.pack([("AA001", {"type": "Polygon", "coordinates": [ring]})])
+        (_, _, polygons), = mr._parse(raw)
+        lat, lng = polygons[0][0][0]
+        assert (lat, lng) == pytest.approx((50.65432, 10.12346), abs=1e-9)
+
+
+class TestSimplification:
+    def test_a_point_on_a_straight_edge_is_dropped(self, bake):
+        ring = [(0, 0), (1, 0), (2, 0), (2, 2), (0, 2), (0, 0)]
+        assert bake.simplify_ring(ring, 0.01) == [(0, 0), (2, 0), (2, 2), (0, 2)]
+
+    def test_a_corner_past_the_tolerance_is_kept(self, bake):
+        ring = [(0, 0), (1, 0.5), (2, 0), (2, 2), (0, 2), (0, 0)]
+        assert (1, 0.5) in bake.simplify_ring(ring, 0.01)
+
+    def test_a_ring_too_small_to_simplify_is_returned_whole(self, bake):
+        assert bake.simplify_ring([(0, 0), (1, 0), (0, 1)], 0.01) == [(0, 0), (1, 0), (0, 1)]
+
+    def test_a_polyline_keeps_its_ends(self, bake):
+        line = [(0, 0), (1, 0.001), (2, -0.001), (3, 0)]
+        assert bake.douglas_peucker(line, 0.01) == [(0, 0), (3, 0)]
+
+
+class TestRegionSelection:
+    """regions() keys each source the way key_for will look it up."""
+
+    def test_sources_are_keyed_by_type_and_aliased_where_a_feed_mislabels(self, bake):
+        geom = {"type": "Polygon", "coordinates": [_square(0, 1, 0, 1)]}
+        geocodes = {"features": [
+            {"properties": {"type": "EMMA_ID", "code": "PL3001", "country": "PL"},
+             "geometry": geom},
+            {"properties": {"type": "EMMA_ID", "code": "MK001", "country": "MK"},
+             "geometry": geom},
+            {"properties": {"type": "NUTS3", "code": "PL911", "country": "PL"},
+             "geometry": geom},
+        ]}
+        nuts3 = {"features": [
+            {"properties": {"CNTR_CODE": "FR", "NUTS_ID": "FR101"}, "geometry": geom},
+            {"properties": {"CNTR_CODE": "DE", "NUTS_ID": "DE111"}, "geometry": geom},
+        ]}
+        nuts2 = {"features": [
+            {"properties": {"CNTR_CODE": "HU", "NUTS_ID": "HU10"}, "geometry": geom},
+            {"properties": {"CNTR_CODE": "FR", "NUTS_ID": "FR10"}, "geometry": geom},
+        ]}
+        orp = {"features": [
+            {"properties": {"kod": 19, "nazev": "Praha"}, "geometry": geom},
+            {"properties": {"kod": 582786, "nazev": "Brno"}, "geometry": geom},
+        ]}
+        cisorp = [{"kod_ruian": "19", "chodnota": "1000"},
+                  {"kod_ruian": "582786", "chodnota": "6203"}]
+
+        items = bake.regions(geocodes, nuts3, nuts2, orp, cisorp)
+
+        assert [key for key, _ in items] == [
+            "CISORP/1000", "CISORP/1100", "CISORP/6203",
+            "MK001", "NUTS2/HU10", "NUTS3/FR101", "NUTS3/MK001", "PL3001",
+        ]
+        for key, geometry in items:
+            assert geometry is geom, key
+
+
+def _coded_feed(area_desc, code):
+    """One Moderate warning naming its ground by EMMA_ID."""
+    return {"warnings": [{"alert": {"info": [{
+        "language": "en-GB", "severity": "Moderate", "event": "Storm",
+        "area": [{"areaDesc": area_desc,
+                  "geocode": [{"valueName": "EMMA_ID", "value": code}]}],
+    }]}}]}
+
+
+def _alerts(data, lat, lng, address):
+    from linecast import _weather_sources as ws
+    with patch.object(ws, "fetch_json_cached", return_value=data), \
+            patch.object(ws, "write_cache", lambda *a, **k: None):
+        return ws._fetch_alerts_meteoalarm(lat, lng, "poland", address=address)
+
+
+class TestLoaderFailsSoft:
+    """Without the file, alerts go back to matching on the area name."""
+
+    @pytest.fixture(autouse=True)
+    def _debug(self, mr):
+        from linecast._runtime import set_debug
+        set_debug(True)
+        yield
+        set_debug(False)
+
+    def _check_fallback(self, mr, capsys):
+        assert mr.regions_at(52.23, 21.01) == set()
+        assert not mr.known("PL1465")
+        mr.regions_at(52.23, 21.01)
+        lines = [line for line in capsys.readouterr().err.splitlines()
+                 if "weather/alerts: meteoalarm regions failed" in line]
+        assert len(lines) == 1, "the failure is logged once, not on every call"
+        assert lines[0].endswith("; matching alerts by area name")
+        # and the area name is what decides, the code counting for nothing
+        data = _coded_feed("powiat chodzieski", "PL3001")
+        assert len(_alerts(data, 52.995, 16.92, {"county": "powiat chodzieski"})) == 1
+        assert _alerts(data, 52.995, 16.92, {"city": "Warszawa"}) == []
+
+    def test_a_missing_file(self, mr, tmp_path, capsys):
+        with patch.object(mr, "_PATH", str(tmp_path / "missing.bin.gz")):
+            self._check_fallback(mr, capsys)
+
+    def test_a_file_of_another_version(self, mr, tmp_path, capsys):
+        path = tmp_path / "v1.bin.gz"
+        path.write_bytes(gzip.compress(b"LCMA\x01\x00\x00"))
+        with patch.object(mr, "_PATH", str(path)):
+            self._check_fallback(mr, capsys)
+
+    def test_a_truncated_file(self, bake, mr, tmp_path, capsys):
+        raw, _ = bake.pack(GEOMETRY)
+        path = tmp_path / "cut.bin.gz"
+        path.write_bytes(gzip.compress(raw[:len(raw) // 2]))
+        with patch.object(mr, "_PATH", str(path)):
+            self._check_fallback(mr, capsys)
+
+    def test_a_file_that_is_not_gzip(self, mr, tmp_path, capsys):
+        path = tmp_path / "plain.bin.gz"
+        path.write_bytes(b"not gzip at all")
+        with patch.object(mr, "_PATH", str(path)):
+            self._check_fallback(mr, capsys)
+
+
+KEY = re.compile(r"[A-Z]{2}[A-Z0-9]+|(NUTS2|NUTS3|CISORP)/[A-Z0-9]+")
+
+
+class TestShippedFile:
+    """The file in the wheel is whole, and covers what the router routes."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self, mr):
+        self.mr = mr
+        self.regions = mr._load()
+        assert self.regions, "the shipped file did not load"
+
+    def test_keys_are_unique_and_spelled_as_key_for_spells_them(self):
+        keys = [key for key, _, _ in self.regions]
+        assert len(set(keys)) == len(keys)
+        assert all(KEY.fullmatch(key) for key in keys)
+
+    def test_every_ring_closes_a_shape_inside_its_bounding_box(self):
+        for key, (lat_min, lat_max, lng_min, lng_max), polygons in self.regions:
+            assert polygons, key
+            for outer, holes in polygons:
+                for ring in (outer, *holes):
+                    assert len(ring) >= 3, key
+                    for lat, lng in ring:
+                        assert lat_min <= lat <= lat_max, key
+                        assert lng_min <= lng <= lng_max, key
+
+    def test_every_meteoalarm_country_has_ground_or_files_polygons(self):
+        # A new member added to the router needs a re-bake; this is
+        # where that shows. Switzerland, the UK and Ukraine put a CAP
+        # polygon on every warning and publish no EMMA regions.
+        from linecast._weather_sources import _METEOALARM_SLUGS
+        emma_countries = {key[:2] for key, _, _ in self.regions if "/" not in key}
+        assert set(_METEOALARM_SLUGS) - emma_countries == {"CH", "GB", "UA"}
+
+    def test_the_typed_regions_are_the_ones_the_bake_script_declares(self, bake):
+        # The countries the script lists under NUTS, plus the alias
+        # written for North Macedonia, and no others: a country added to
+        # the script without a re-bake, or baked and then dropped from
+        # the script, fails here.
+        by_type = {}
+        for key, _, _ in self.regions:
+            kind, _, code = key.partition("/")
+            if code:
+                by_type.setdefault(kind, set()).add(code[:2])
+        expected = {level: set(countries) for level, countries in bake.NUTS.items()}
+        for country, level in bake.ALIASES.items():
+            expected.setdefault(level, set()).add(country)
+        cisorp = by_type.pop("CISORP", set())  # Czech ORP codes carry no country
+        assert by_type == expected
+        assert {"10", "11"} <= cisorp  # Prague, under both its spellings
+
+    def test_a_lookup_is_quick(self):
+        # A weather call in Europe pays this once; it must not be felt.
+        import time
+        start = time.perf_counter()
+        for _ in range(20):
+            self.mr.regions_at(48.8566, 2.3522)
+        assert (time.perf_counter() - start) / 20 < 0.05

--- a/tests/test_weather_parsing.py
+++ b/tests/test_weather_parsing.py
@@ -312,6 +312,33 @@ class TestMeteoAlarmAlerts:
 # JMA alerts parsing
 # ---------------------------------------------------------------------------
 
+class TestMeteoAlarmFeedSize:
+    """A feed that outlines every warning is bigger than fetch_json allows."""
+
+    def test_the_feed_is_fetched_under_a_wider_cap(self):
+        from linecast import _weather_sources as ws
+        from linecast._http import MAX_JSON_BYTES
+        seen = {}
+
+        def miss(cache_file, max_age, url, **kwargs):
+            # a cache miss: fetch_json_cached hands the network step to `fetch`
+            return kwargs["fetch"](url, timeout=kwargs["timeout"])
+
+        def fetch_json(url, headers=None, timeout=10, limit=MAX_JSON_BYTES):
+            seen.update(url=url, limit=limit, accept=(headers or {}).get("Accept"))
+            return {"warnings": []}
+
+        with patch.object(ws, "fetch_json_cached", side_effect=miss), \
+                patch.object(ws, "fetch_json", fetch_json), \
+                patch.object(ws, "write_cache", lambda *a, **k: None):
+            ws._fetch_alerts_meteoalarm(46.95, 7.45, "switzerland", address={})
+        assert seen["url"].endswith("/feeds-switzerland")
+        assert seen["accept"] == "application/json"
+        assert seen["limit"] == ws._METEOALARM_FEED_BYTES
+        # 9.4 MB on a quiet September day; give a stormy one room
+        assert seen["limit"] >= 3 * MAX_JSON_BYTES
+
+
 class TestJMAAlerts:
     """Verify we can parse a real JMA warning response."""
 


### PR DESCRIPTION
A robustness pass after the MeteoAlarm work on `next` (#57, #58, #59). Four commits, each standing alone.

## A real bug the new probe found

`fetch_json` refuses a body over 8 MiB. The Swiss feed puts a CAP polygon on every warning and was 9.4 MB today; the refusal was absorbed as a fetch failure and Switzerland read as a quiet day, with no alerts at all. The MeteoAlarm fetch now goes through the cached fetch's `fetch` hook with a 32 MiB cap of its own. The general cap is untouched.

## Tests for the region file's contract

`tests/test_meteoalarm_regions.py` is new. It checks what nothing checked before:

- `pack()` in the bake script and `_parse()` in the runtime round-trip a multipolygon with a hole, through gzip and off disk, and the simplifier keeps corners and drops collinear points.
- `regions()` keys each source the way `key_for` looks it up, aliasing North Macedonia and spelling Prague both ways.
- The loader fails soft: a missing, older-version, truncated, or non-gzip file logs once and sends alerts back to area-name matching.
- The shipped file is whole: unique keys spelled as `key_for` spells them, every ring inside its bounding box, every country in the router carrying EMMA ground or known to file polygons, and the typed regions matching what the bake script declares. A country added to the router or the script without a re-bake fails here.

## The daily live probe asks every feed

`test_live_providers.py` now fetches all 35 MeteoAlarm feeds under the runtime's cap and fails naming any area with neither a polygon nor a geocode the file knows. That is the check the issue wanted at bake time, run daily instead. All 35 pass today.

## One locale gap

The Indonesian tides table lacked the wave and swell words and fell back to English. Now gelombang and alun.

## Verified

- `pytest tests`: 2325 passed, 12 skipped.
- `ruff check src tests scripts`: clean.
- The live probe run by hand: 35 of 35 feeds placed, Switzerland included once the cap change was in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HMKwn9kFwMCBtjCCWeSai

---
_Generated by [Claude Code](https://claude.ai/code/session_019HMKwn9kFwMCBtjCCWeSai)_